### PR TITLE
fix: Update repository URL in VS Code extension package.json

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -144,7 +144,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/james401/ai-use-case-hub.git"
+    "url": "https://github.com/mt-osiris-tools/ai-use-case-cli.git"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- Fixed last remaining `james401` reference to `mt-osiris-tools`
- Corrected repository URL in VS Code extension package.json
- Changed from hub repository URL to CLI repository URL

## Changes
- Updated `vscode-extension/package.json` line 147
- Changed: `https://github.com/james401/ai-use-case-hub.git`
- To: `https://github.com/mt-osiris-tools/ai-use-case-cli.git`

## Why
- Completes the organization migration from james401 to mt-osiris-tools
- The VS Code extension is part of the CLI tools repository, not the hub
- Ensures consistency across all repository references

## Test Plan
- [x] Verified no remaining `james401` references in codebase
- [x] Confirmed repository URL points to correct CLI repository
- [x] Package.json syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)