### PR TITLE
fix: update sync script version display to v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2025-11-03
+
+### Fixed
+
+- Updated version display in `sync-ai-use-cases.sh` from v2.3.0/v2.0 to v3.1.1 for consistency with main CLI version
+
 ## [3.1.0] - 2025-11-02
 
 ### 🎉 Major Update: Hybrid CLI + Claude Code Interface

--- a/ai-use-case
+++ b/ai-use-case
@@ -16,7 +16,7 @@ CYAN=$'\033[0;36m'
 NC=$'\033[0m'
 
 # Version
-VERSION="3.1.0"
+VERSION="3.1.1"
 
 # Get script directory (resolve symlinks)
 SCRIPT_PATH="${BASH_SOURCE[0]}"

--- a/sync-ai-use-cases.sh
+++ b/sync-ai-use-cases.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# AI Use Cases Sync Script v2.3.0
+# AI Use Cases Sync Script v3.1.1
 # Syncs AI use case documentation from project directories to a central location
 # Uses symlinks to avoid duplication - files are stored once in by-project/
 #
@@ -64,7 +64,7 @@ BY_TOPIC_DIR="$CENTRAL_DIR/by-topic"
 
 # Show help
 if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
-    echo "AI Use Cases Sync Script v2.0"
+    echo "AI Use Cases Sync Script v3.1.1"
     echo ""
     echo "Usage:"
     echo "  $0 [project_path]"
@@ -102,7 +102,7 @@ else
     PROJECT_NAME=$(basename "$PROJECT_PATH")
 fi
 
-echo -e "${GREEN}=== AI Use Cases Sync v2.3.0 ===${NC}"
+echo -e "${GREEN}=== AI Use Cases Sync v3.1.1 ===${NC}"
 echo "Project: $PROJECT_NAME"
 echo "Source: $PROJECT_PATH"
 echo "Central: $CENTRAL_DIR"


### PR DESCRIPTION
## Summary

Fixes outdated version display in sync script that was showing v2.3.0/v2.0 instead of the current CLI version.

## Problem

When running `ai-use-case --init` or `sync`, the sync script displayed outdated version numbers:
- Header comment: v2.3.0
- Help message: v2.0
- Output banner: v2.3.0

This caused confusion for users like those with the lms-medtrainer project, who saw v2.3.0 even though the main CLI was at v3.1.0.

## Solution

Updated all version references to v3.1.1:
- Main CLI version in `ai-use-case` (line 19)
- Three locations in `sync-ai-use-cases.sh` (lines 2, 67, 105)
- Added v3.1.1 entry to CHANGELOG.md

## Changes

- ✅ Updated VERSION in `ai-use-case` from 3.1.0 to 3.1.1
- ✅ Updated `sync-ai-use-cases.sh` version references (3 locations)
- ✅ Added CHANGELOG entry for v3.1.1
- ✅ Tested: `./ai-use-case --version` shows v3.1.1
- ✅ Tested: `./sync-ai-use-cases.sh --help` shows v3.1.1
- ✅ Tested: sync output banner shows v3.1.1

## Type

- [x] Bug fix (patch version bump)
- [ ] New feature
- [ ] Breaking change

## Testing

```bash
# Test CLI version
./ai-use-case --version
# Output: ai-use-case version 3.1.1

# Test sync script help
./sync-ai-use-cases.sh --help
# Output: AI Use Cases Sync Script v3.1.1

# Test sync output
./sync-ai-use-cases.sh ~/Documents/medtrainer/lms-medtrainer
# Output: === AI Use Cases Sync v3.1.1 ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)