### PR TITLE
feat: add centralized version management system (v3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2025-11-03
+
+### Added
+
+- **Centralized Version Management**: Introduced `version.sh` as single source of truth for CLI version
+  - All scripts now source version from `version.sh` instead of hardcoding
+  - Eliminates version drift across scripts
+  - Simplifies version bumps - update one file instead of multiple
+  - Includes version history and bump instructions in comments
+
+### Changed
+
+- **Updated version retrieval in all scripts**:
+  - `ai-use-case`: Sources `version.sh` for VERSION variable
+  - `sync-ai-use-cases.sh`: Sources `version.sh` for display banner
+  - `registry-manager.sh`: `get_cli_version()` now reads from `version.sh`
+  - `document-ai-session.sh`: Updated local and remote version checks to use `version.sh`
+  - `install.sh`: Updated remote and installed version checks to use `version.sh`
+- Remote version checks now fetch `version.sh` instead of grepping `ai-use-case`
+- All version display messages now use `$CLI_VERSION` variable
+
+### Fixed
+
+- Prevents future version inconsistencies like the v2.3.0 issue in sync script
+- Makes version management more maintainable and less error-prone
+
 ## [3.1.1] - 2025-11-03
 
 ### Fixed

--- a/ai-use-case
+++ b/ai-use-case
@@ -15,15 +15,22 @@ RED=$'\033[0;31m'
 CYAN=$'\033[0;36m'
 NC=$'\033[0m'
 
-# Version
-VERSION="3.1.1"
-
 # Get script directory (resolve symlinks)
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if [ -L "$SCRIPT_PATH" ]; then
     SCRIPT_PATH="$(readlink -f "$SCRIPT_PATH")"
 fi
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+# Source version configuration (single source of truth)
+if [ -f "$SCRIPT_DIR/version.sh" ]; then
+    source "$SCRIPT_DIR/version.sh"
+    VERSION="$CLI_VERSION"
+else
+    # Fallback if version.sh is missing
+    echo "Warning: version.sh not found, using fallback version" >&2
+    VERSION="unknown"
+fi
 
 # Show help
 show_help() {

--- a/document-ai-session.sh
+++ b/document-ai-session.sh
@@ -34,11 +34,11 @@ NC='\033[0m'
 # Get script directory early for version checking
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Get CLI version
+# Get CLI version from version.sh (single source of truth)
 get_cli_version() {
-    local cli_path="$SCRIPT_DIR/ai-use-case"
-    if [ -f "$cli_path" ]; then
-        grep '^VERSION=' "$cli_path" | head -1 | cut -d'"' -f2
+    local version_file="$SCRIPT_DIR/version.sh"
+    if [ -f "$version_file" ]; then
+        (source "$version_file" && echo "$CLI_VERSION")
     else
         echo "unknown"
     fi
@@ -71,9 +71,9 @@ check_cli_version() {
     if [ -z "$remote_version" ]; then
         echo -e "${BLUE}Checking CLI version...${NC}"
         if command -v curl &> /dev/null; then
-            remote_version=$(curl -s -m 3 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/ai-use-case 2>/dev/null | grep '^VERSION=' | head -1 | cut -d'"' -f2)
+            remote_version=$(curl -s -m 3 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/version.sh 2>/dev/null | grep '^export CLI_VERSION=' | head -1 | cut -d'"' -f2)
         elif command -v wget &> /dev/null; then
-            remote_version=$(wget -qO- -T 3 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/ai-use-case 2>/dev/null | grep '^VERSION=' | head -1 | cut -d'"' -f2)
+            remote_version=$(wget -qO- -T 3 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/version.sh 2>/dev/null | grep '^export CLI_VERSION=' | head -1 | cut -d'"' -f2)
         fi
         # Update cache (even if empty, to avoid repeated attempts)
         {

--- a/install.sh
+++ b/install.sh
@@ -19,22 +19,22 @@ CYAN=$'\033[0;36m'
 YELLOW=$'\033[1;33m'
 NC=$'\033[0m' # No Color
 
-# Function to get remote version
+# Function to get remote version from version.sh (single source of truth)
 get_remote_version() {
     local remote_version=""
     if command -v curl &> /dev/null; then
-        remote_version=$(curl -s -m 2 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/ai-use-case 2>/dev/null | grep '^VERSION=' | head -1 | cut -d'"' -f2)
+        remote_version=$(curl -s -m 2 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/version.sh 2>/dev/null | grep '^export CLI_VERSION=' | head -1 | cut -d'"' -f2)
     elif command -v wget &> /dev/null; then
-        remote_version=$(wget -qO- -T 2 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/ai-use-case 2>/dev/null | grep '^VERSION=' | head -1 | cut -d'"' -f2)
+        remote_version=$(wget -qO- -T 2 https://raw.githubusercontent.com/mt-osiris-tools/ai-use-case-cli/main/version.sh 2>/dev/null | grep '^export CLI_VERSION=' | head -1 | cut -d'"' -f2)
     fi
     echo "$remote_version"
 }
 
-# Function to get installed version
+# Function to get installed version from version.sh (single source of truth)
 get_installed_version() {
     local install_dir="$HOME/.local/share/ai-use-case-cli"
-    if [ -f "$install_dir/ai-use-case" ]; then
-        grep '^VERSION=' "$install_dir/ai-use-case" 2>/dev/null | head -1 | cut -d'"' -f2
+    if [ -f "$install_dir/version.sh" ]; then
+        (source "$install_dir/version.sh" && echo "$CLI_VERSION")
     else
         echo ""
     fi

--- a/registry-manager.sh
+++ b/registry-manager.sh
@@ -39,13 +39,14 @@ EOF
     fi
 }
 
-# Get CLI version from the ai-use-case script
+# Get CLI version from version.sh (single source of truth)
 get_cli_version() {
     local script_dir="$1"
-    local ai_use_case_script="$script_dir/ai-use-case"
+    local version_file="$script_dir/version.sh"
 
-    if [ -f "$ai_use_case_script" ]; then
-        grep '^VERSION=' "$ai_use_case_script" | cut -d'"' -f2
+    if [ -f "$version_file" ]; then
+        # Source version.sh and return CLI_VERSION
+        (source "$version_file" && echo "$CLI_VERSION")
     else
         echo "unknown"
     fi

--- a/sync-ai-use-cases.sh
+++ b/sync-ai-use-cases.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# AI Use Cases Sync Script v3.1.1
+# AI Use Cases Sync Script
 # Syncs AI use case documentation from project directories to a central location
 # Uses symlinks to avoid duplication - files are stored once in by-project/
+#
+# Version is sourced from version.sh (single source of truth)
 #
 # Usage:
 #   ./sync-ai-use-cases.sh [project_path]
@@ -57,6 +59,16 @@ ensure_hub_exists() {
 
 # Configuration - Auto-detect hub location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source version configuration (single source of truth)
+if [ -f "$SCRIPT_DIR/version.sh" ]; then
+    source "$SCRIPT_DIR/version.sh"
+else
+    # Fallback if version.sh is missing
+    echo "Warning: version.sh not found, using fallback version" >&2
+    CLI_VERSION="unknown"
+fi
+
 CENTRAL_DIR=$(ensure_hub_exists)
 BY_PROJECT_DIR="$CENTRAL_DIR/by-project"
 BY_DATE_DIR="$CENTRAL_DIR/by-date"
@@ -64,7 +76,7 @@ BY_TOPIC_DIR="$CENTRAL_DIR/by-topic"
 
 # Show help
 if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
-    echo "AI Use Cases Sync Script v3.1.1"
+    echo "AI Use Cases Sync Script v${CLI_VERSION}"
     echo ""
     echo "Usage:"
     echo "  $0 [project_path]"
@@ -102,7 +114,7 @@ else
     PROJECT_NAME=$(basename "$PROJECT_PATH")
 fi
 
-echo -e "${GREEN}=== AI Use Cases Sync v3.1.1 ===${NC}"
+echo -e "${GREEN}=== AI Use Cases Sync v${CLI_VERSION} ===${NC}"
 echo "Project: $PROJECT_NAME"
 echo "Source: $PROJECT_PATH"
 echo "Central: $CENTRAL_DIR"

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# AI Use Case CLI - Version Configuration
+# Single source of truth for CLI version
+#
+# This file should be sourced by all scripts that need version information.
+# When bumping the version, only update this file - all scripts will automatically
+# use the new version.
+#
+# Version Format: MAJOR.MINOR.PATCH
+# - MAJOR: Breaking changes (X.0.0)
+# - MINOR: New features (0.X.0)
+# - PATCH: Bug fixes (0.0.X)
+#
+# To bump version:
+# 1. Update CLI_VERSION below
+# 2. Update CHANGELOG.md with changes
+# 3. Test all commands (ai-use-case --version, sync, etc.)
+# 4. Commit with message: "chore: bump version to X.Y.Z"
+
+# Current CLI version
+export CLI_VERSION="3.2.0"
+
+# Version history (for reference)
+# 3.2.0 - 2025-11-03 - Centralized version constant (single source of truth)
+# 3.1.1 - 2025-11-03 - Fixed version display in sync script
+# 3.1.0 - 2025-11-02 - Hybrid CLI + Project Registry
+# 3.0.0 - 2025-11-02 - Claude Code integration
+# 2.3.0 - Previous standalone CLI version


### PR DESCRIPTION
## Summary

Introduces `version.sh` as the single source of truth for CLI version, eliminating version drift and making version management significantly easier.

## Problem

The recent v3.1.1 fix revealed a systemic issue with version management:
- Version numbers were hardcoded across multiple files
- This led to version inconsistencies (sync script showing v2.3.0 while main CLI was at v3.1.0)
- Each version bump required updating multiple files
- Error-prone and difficult to maintain

## Solution

Created a centralized version management system:

### New File: `version.sh`
```bash
#!/bin/bash
# AI Use Case CLI - Version Configuration
# Single source of truth for CLI version

export CLI_VERSION="3.2.0"

# Includes:
# - Version bump instructions
# - Version history for reference
# - Clear documentation
```

### Updated Scripts

All scripts now source `version.sh` instead of hardcoding versions:

**Main Scripts:**
- `ai-use-case`: Sources version.sh for VERSION variable
- `sync-ai-use-cases.sh`: Sources version.sh for display banner

**Version Retrieval Functions:**
- `registry-manager.sh`: `get_cli_version()` reads from version.sh
- `document-ai-session.sh`: Updated local and remote version checks
- `install.sh`: Updated remote and installed version retrieval

**Remote Checks:**
- All remote version checks now fetch `version.sh` from GitHub
- Changed from `grep '^VERSION=' ai-use-case` to `grep '^export CLI_VERSION=' version.sh`

## Benefits

✅ **Single source of truth** - Update version in ONE place  
✅ **Prevents version drift** - Impossible to have inconsistent versions  
✅ **Easier version bumps** - Edit one file instead of 5+  
✅ **More maintainable** - Clear documentation and history  
✅ **Less error-prone** - No more forgetting to update a script  

## Future Version Bumps

Now it's as simple as:
```bash
# 1. Edit version.sh
export CLI_VERSION="3.3.0"

# 2. Update CHANGELOG.md
# 3. Test and commit
```

No more hunting through multiple files!

## Testing

Comprehensive testing performed:

```bash
# Test main CLI
$ ./ai-use-case --version
ai-use-case version 3.2.0

# Test sync script
$ ./sync-ai-use-cases.sh --help
AI Use Cases Sync Script v3.2.0

# Test registry manager
$ source ./registry-manager.sh && get_cli_version "$(pwd)"
3.2.0

# Test version.sh directly
$ source ./version.sh && echo $CLI_VERSION
3.2.0
```

All tests pass! ✅

## Files Changed

- ➕ **NEW**: `version.sh` - Centralized version configuration
- 📝 `ai-use-case` - Sources version.sh
- 📝 `sync-ai-use-cases.sh` - Sources version.sh
- 📝 `registry-manager.sh` - Updated get_cli_version()
- 📝 `document-ai-session.sh` - Updated version checks
- 📝 `install.sh` - Updated version retrieval
- 📝 `CHANGELOG.md` - Added v3.2.0 entry

## Type

- [x] New feature (minor version bump: 3.1.1 → 3.2.0)
- [ ] Bug fix
- [ ] Breaking change

## Relation to PR #35

This PR builds on the immediate fix in PR #35 by addressing the root cause. While #35 fixed the v2.3.0 display issue, this PR ensures it can never happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)