### PR TITLE
fix: correct script paths in Claude Code slash commands

### DIFF
--- a/.claude/commands/use-case/check-updates.md
+++ b/.claude/commands/use-case/check-updates.md
@@ -10,7 +10,7 @@ Check all registered projects and report which ones are running outdated version
 
 Run the check-updates script:
 ```bash
-bash ~/.local/share/ai-use-case-cli/check-updates.sh
+bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh
 ```
 
 ## Available Options
@@ -18,19 +18,19 @@ bash ~/.local/share/ai-use-case-cli/check-updates.sh
 ### Default (Pretty Output)
 Shows detailed information about outdated projects:
 ```bash
-bash ~/.local/share/ai-use-case-cli/check-updates.sh
+bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh
 ```
 
 ### JSON Output
 For programmatic processing:
 ```bash
-bash ~/.local/share/ai-use-case-cli/check-updates.sh --json
+bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh --json
 ```
 
 ### Paths Only
 Get only project paths (useful for scripting):
 ```bash
-bash ~/.local/share/ai-use-case-cli/check-updates.sh --paths-only
+bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh --paths-only
 ```
 
 ## Information Displayed
@@ -52,19 +52,19 @@ After checking for updates, offer to:
 
 ### 1. Update a Single Project
 ```bash
-bash ~/.local/share/ai-use-case-cli/update-project.sh /path/to/project
+bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh /path/to/project
 ```
 
 ### 2. Update All Outdated Projects
 ```bash
-for p in $(bash ~/.local/share/ai-use-case-cli/check-updates.sh --paths-only); do
-  bash ~/.local/share/ai-use-case-cli/update-project.sh "$p"
+for p in $(bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh --paths-only); do
+  bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh "$p"
 done
 ```
 
 ### 3. View Project Details
 ```bash
-bash ~/.local/share/ai-use-case-cli/list-projects.sh --registry-only
+bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh --registry-only
 ```
 
 ## Interaction Flow

--- a/.claude/commands/use-case/list-projects.md
+++ b/.claude/commands/use-case/list-projects.md
@@ -10,7 +10,7 @@ Display all projects that are using the AI Use Case CLI, showing both hub inform
 
 Run the list-projects script:
 ```bash
-bash ~/.local/share/ai-use-case-cli/list-projects.sh
+bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh
 ```
 
 ## Available Options
@@ -18,19 +18,19 @@ bash ~/.local/share/ai-use-case-cli/list-projects.sh
 ### Show All Information (Default)
 Shows both hub projects and registry information:
 ```bash
-bash ~/.local/share/ai-use-case-cli/list-projects.sh
+bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh
 ```
 
 ### Registry Only
 Show only registered projects with version details:
 ```bash
-bash ~/.local/share/ai-use-case-cli/list-projects.sh --registry-only
+bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh --registry-only
 ```
 
 ### Hub Only
 Show only projects in the hub with use case counts:
 ```bash
-bash ~/.local/share/ai-use-case-cli/list-projects.sh --hub-only
+bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh --hub-only
 ```
 
 ## Information Displayed
@@ -52,7 +52,7 @@ After viewing the projects, you can offer to:
 
 1. **Check for updates** if outdated projects are shown:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/check-updates.sh
+   bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh
    ```
 
 2. **View use cases** for a specific project:
@@ -62,12 +62,12 @@ After viewing the projects, you can offer to:
 
 3. **Update a project** to the latest version:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/update-project.sh /path/to/project
+   bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh /path/to/project
    ```
 
 4. **Search use cases** across all projects:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/search-use-cases.sh <term>
+   bash ~/.local/share/ai-use-case-cli/scripts/search/search-use-cases.sh <term>
    ```
 
 ## Interaction Flow

--- a/.claude/commands/use-case/sync-usecases.md
+++ b/.claude/commands/use-case/sync-usecases.md
@@ -22,18 +22,18 @@ Run the sync script to copy use case documents from the current project to the c
 
 3. Run the sync:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/sync-ai-use-cases.sh .
+   bash ~/.local/share/ai-use-case-cli/scripts/core/sync-ai-use-cases.sh .
    ```
 
 4. Show the results:
    ```bash
    # Show synced files stats
-   bash ~/.local/share/ai-use-case-cli/stats-use-cases.sh
+   bash ~/.local/share/ai-use-case-cli/scripts/search/stats-use-cases.sh
    ```
 
 5. Optionally show recent use cases:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/list-projects.sh
+   bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh
    ```
 
 ## When to Use This

--- a/.claude/commands/use-case/update-project.md
+++ b/.claude/commands/use-case/update-project.md
@@ -10,26 +10,26 @@ Update a specific project's CLI installation to the latest version, ensuring all
 
 Run the update-project script with the project path:
 ```bash
-bash ~/.local/share/ai-use-case-cli/update-project.sh /path/to/project
+bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh /path/to/project
 ```
 
 ## Usage
 
 ### Update Current Directory
 ```bash
-bash ~/.local/share/ai-use-case-cli/update-project.sh .
+bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh .
 ```
 
 ### Update Specific Project
 ```bash
-bash ~/.local/share/ai-use-case-cli/update-project.sh /full/path/to/project
+bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh /full/path/to/project
 ```
 
 ### Update Multiple Projects
 ```bash
 # Update all outdated projects
-for p in $(bash ~/.local/share/ai-use-case-cli/check-updates.sh --paths-only); do
-  bash ~/.local/share/ai-use-case-cli/update-project.sh "$p"
+for p in $(bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh --paths-only); do
+  bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh "$p"
 done
 ```
 
@@ -90,23 +90,23 @@ If the script reports an error:
 ```
 User: "Update this project"
 Assistant: "I'll update the current project to the latest CLI version."
-[Runs: bash ~/.local/share/ai-use-case-cli/update-project.sh .]
+[Runs: bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh .]
 ```
 
 **Updating specific project:**
 ```
 User: "Update my-app to the latest version"
 Assistant: "I'll update the my-app project. Let me find the registered path first."
-[Runs: bash ~/.local/share/ai-use-case-cli/list-projects.sh --registry-only]
+[Runs: bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh --registry-only]
 [Finds path: /home/user/Projects/my-app]
-[Runs: bash ~/.local/share/ai-use-case-cli/update-project.sh /home/user/Projects/my-app]
+[Runs: bash ~/.local/share/ai-use-case-cli/scripts/project/update-project.sh /home/user/Projects/my-app]
 ```
 
 **Multiple projects:**
 ```
 User: "Update all my projects"
 Assistant: "I'll check which projects need updates and update them all."
-[Runs: bash ~/.local/share/ai-use-case-cli/check-updates.sh]
+[Runs: bash ~/.local/share/ai-use-case-cli/scripts/project/check-updates.sh]
 [Shows list of outdated projects]
 [Asks: "Update all X projects? This will run the setup script for each."]
 [If yes, runs update-project.sh for each path]
@@ -127,7 +127,7 @@ After successfully updating, suggest:
 
 1. **Verify the update**:
    ```bash
-   bash ~/.local/share/ai-use-case-cli/list-projects.sh --registry-only
+   bash ~/.local/share/ai-use-case-cli/scripts/project/list-projects.sh --registry-only
    ```
 
 2. **Test in Claude Code**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Slash Command Paths**: Fixed incorrect script paths in Claude Code slash commands
+  - Updated `/use-case:update-project` to use correct `scripts/project/update-project.sh` path
+  - Updated `/use-case:check-updates` to use correct `scripts/project/check-updates.sh` path
+  - Updated `/use-case:list-projects` to use correct `scripts/project/list-projects.sh` path
+  - Updated `/use-case:sync-usecases` to use correct `scripts/core/sync-ai-use-cases.sh` and `scripts/search/stats-use-cases.sh` paths
+  - Fixes "No such file or directory" errors when running these commands on outdated CLI installations
+
 - **Installer Update Process**: Enhanced installer to handle local modifications automatically
   - Detects and gracefully handles permission-only changes (automatically discarded with `git reset --hard`)
   - Stashes actual content changes before update and re-applies them after


### PR DESCRIPTION
Fixed incorrect paths in slash commands that were causing "No such file or directory" errors when running commands on outdated CLI installations.

Changes:
- /use-case:update-project - Fixed paths to scripts/project/
- /use-case:check-updates - Fixed paths to scripts/project/
- /use-case:list-projects - Fixed paths to scripts/project/
- /use-case:sync-usecases - Fixed paths to scripts/core/ and scripts/search/

All script references now use the correct directory structure:
- scripts/project/ for: check-updates.sh, list-projects.sh, update-project.sh
- scripts/core/ for: sync-ai-use-cases.sh
- scripts/search/ for: stats-use-cases.sh, search-use-cases.sh

This resolves the error:
"bash: ~/.local/share/ai-use-case-cli/check-updates.sh: No such file or directory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)