### PR TITLE
Fix: Update README.md version references to 3.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img src="./media/ai_use_case_cli_banner.webp" alt="AI Use Case CLI - The Documenter" width="800"/>
     <h1>AI Use Case CLI</h1>
-    <h3><em><strong>v3.4.2</strong> - Document AI-assisted development workflows with ease.</em></h3>
+    <h3><em><strong>v3.4.3</strong> - Document AI-assisted development workflows with ease.</em></h3>
 </div>
 
 ---
@@ -362,5 +362,5 @@ MIT License - see [LICENSE](./LICENSE) file for details
 
 ---
 
-**Version**: 3.4.2
-**Last Updated**: 2025-11-08
+**Version**: 3.4.3
+**Last Updated**: 2025-11-09


### PR DESCRIPTION
## Summary

- Fixed version discrepancies in README.md to match current CLI version (3.4.3)
- Updated header version badge: v3.4.2 → v3.4.3
- Updated footer version and date: 3.4.2 (2025-11-08) → 3.4.3 (2025-11-09)

## Context

The CLI version was bumped to 3.4.3 in `scripts/utils/version.sh` and `CHANGELOG.md` was updated, but README.md still referenced v3.4.2 in two locations.

## Changes

- `README.md:4` - Header version badge
- `README.md:365-366` - Footer version and last updated date

## Test Plan

- [x] Verified version in `scripts/utils/version.sh` is 3.4.3
- [x] Verified CHANGELOG.md has entry for [3.4.3] - 2025-11-09
- [x] Confirmed README.md now shows 3.4.3 in both locations
- [x] All other version references are contextually correct (e.g., "v3.4.0+ Interactive session")

🤖 Generated with [Claude Code](https://claude.com/claude-code)