### PR TITLE
fix: update sync script path in document-session slash command

### DIFF
--- a/.claude/commands/use-case/document-session.md
+++ b/.claude/commands/use-case/document-session.md
@@ -297,7 +297,7 @@ Create documentation file but DO NOT commit (since there are no code changes):
 
 **Then sync to central hub (both session types):**
 ```bash
-bash ~/.local/share/ai-use-case-cli/sync-ai-use-cases.sh .
+bash ~/.local/share/ai-use-case-cli/scripts/core/sync-ai-use-cases.sh .
 ```
 
 ## Key Principles


### PR DESCRIPTION
## Bug Fix

Fixes outdated path reference in the document-session slash command that was causing sync failures.

---

## Problem

The `/use-case:document-session` slash command was using an old path to the sync script:

**Old Path (broken):**
```bash
bash ~/.local/share/ai-use-case-cli/sync-ai-use-cases.sh .
```

**Error:**
```
bash: /home/james/.local/share/ai-use-case-cli/sync-ai-use-cases.sh: No such file or directory
```

The sync script moved to `scripts/core/` in an earlier version, but this slash command wasn't updated.

---

## Solution

Updated path to correct location:

**New Path (correct):**
```bash
bash ~/.local/share/ai-use-case-cli/scripts/core/sync-ai-use-cases.sh .
```

---

## Testing

```bash
# Test sync command
cd ~/Documents/medtrainer/lms-medtrainer
ai-use-case sync
# ✓ === AI Use Cases Sync v3.6.0 ===
# ✓ Sync successful
```

---

## Impact

**Severity:** 🟡 Medium - Affects `/use-case:document-session` slash command  
**Affected:** Users trying to use Claude Code slash command for documentation  
**Fix:** Simple path correction, no logic changes  

---

## Checklist

- [x] Updated slash command path
- [x] Tested sync works
- [x] No breaking changes
- [x] Single line change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)