### PR TITLE
fix: resolve tracing dependency installation on externally-managed Python environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tracing Dependency Installation**: Fixed installation failure on externally-managed Python environments
+  - Changed from `pip3 install --user` to virtual environment approach (`~/.local/share/ai-use-case-cli/venv`)
+  - Updated `scripts/utils/tracing.sh` to create and use isolated venv for OpenTelemetry packages
+  - Updated `scripts/utils/tracing.py` to make subprocess instrumentation optional (package not available in PyPI)
+  - Resolves PEP 668 externally-managed-environment errors on modern Debian/Ubuntu systems
+  - Added `AI_USECASE_VENV_DIR` environment variable to customize venv location
+  - Automatic fallback to system Python if venv not available
+
 ## [3.6.0] - 2025-11-09
 
 ### Added

--- a/scripts/utils/tracing.py
+++ b/scripts/utils/tracing.py
@@ -28,12 +28,19 @@ try:
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.resources import Resource
-    from opentelemetry.instrumentation.subprocess import SubprocessInstrumentor
     from opentelemetry.trace.status import Status, StatusCode
     from opentelemetry.semconv.trace import SpanAttributes
     TELEMETRY_AVAILABLE = True
+
+    # Subprocess instrumentation is optional
+    try:
+        from opentelemetry.instrumentation.subprocess import SubprocessInstrumentor
+        SUBPROCESS_INSTRUMENTATION_AVAILABLE = True
+    except ImportError:
+        SUBPROCESS_INSTRUMENTATION_AVAILABLE = False
 except ImportError:
     TELEMETRY_AVAILABLE = False
+    SUBPROCESS_INSTRUMENTATION_AVAILABLE = False
 
 class TracingManager:
     """Manages OpenTelemetry tracing setup and operations for the AI Use Case CLI."""
@@ -144,8 +151,9 @@ class TracingManager:
             metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[metric_reader]))
             self.meter = metrics.get_meter(__name__)
             
-            # Auto-instrument subprocess calls
-            SubprocessInstrumentor().instrument()
+            # Auto-instrument subprocess calls (optional)
+            if SUBPROCESS_INSTRUMENTATION_AVAILABLE:
+                SubprocessInstrumentor().instrument()
             
             self.enabled = True
             

--- a/scripts/utils/tracing.sh
+++ b/scripts/utils/tracing.sh
@@ -6,10 +6,23 @@
 TRACING_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TRACING_PY="$TRACING_SCRIPT_DIR/tracing.py"
 
+# Virtual environment for tracing dependencies
+TRACING_VENV_DIR="${AI_USECASE_VENV_DIR:-$HOME/.local/share/ai-use-case-cli/venv}"
+TRACING_PYTHON="${TRACING_VENV_DIR}/bin/python3"
+
+# Determine which Python to use (prefer venv if available)
+if [ -x "$TRACING_PYTHON" ]; then
+    PYTHON_CMD="$TRACING_PYTHON"
+elif command -v python3 &> /dev/null; then
+    PYTHON_CMD="python3"
+else
+    PYTHON_CMD=""
+fi
+
 # Check if Python is available and tracing module works
 TRACING_AVAILABLE=false
-if command -v python3 &> /dev/null && [ -f "$TRACING_PY" ]; then
-    if python3 -c "import sys; sys.path.insert(0, '$TRACING_SCRIPT_DIR'); from tracing import is_tracing_enabled; print('OK')" 2>/dev/null | grep -q "OK"; then
+if [ -n "$PYTHON_CMD" ] && [ -f "$TRACING_PY" ]; then
+    if "$PYTHON_CMD" -c "import sys; sys.path.insert(0, '$TRACING_SCRIPT_DIR'); from tracing import is_tracing_enabled; print('OK')" 2>/dev/null | grep -q "OK"; then
         TRACING_AVAILABLE=true
     fi
 fi
@@ -17,7 +30,7 @@ fi
 # Function to check if tracing is enabled
 is_tracing_enabled() {
     if [ "$TRACING_AVAILABLE" = true ]; then
-        python3 -c "
+        "$PYTHON_CMD" -c "
 import sys
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
 from tracing import is_tracing_enabled
@@ -41,7 +54,7 @@ trace_command_start() {
         # Create a unique trace ID for this command execution
         export TRACE_ID="$(date +%s)_$$_$(printf '%s' "$command" | sed 's/[^a-zA-Z0-9]/_/g')"
         
-        python3 -c "
+        "$PYTHON_CMD" -c "
 import sys
 import os
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
@@ -70,7 +83,7 @@ trace_command_end() {
             duration="$(echo "$end_time - $TRACE_START_TIME" | bc 2>/dev/null || echo "0")"
         fi
         
-        python3 -c "
+        "$PYTHON_CMD" -c "
 import sys
 import os
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
@@ -121,7 +134,7 @@ trace_operation() {
     fi
 
     if [ "$TRACING_AVAILABLE" = true ] && is_tracing_enabled; then
-        TRACE_OPERATION="$operation" TRACE_ATTRS="$attrs_json" python3 -c "
+        TRACE_OPERATION="$operation" TRACE_ATTRS="$attrs_json" "$PYTHON_CMD" -c "
 import sys
 import os
 import json
@@ -148,7 +161,7 @@ trace_file_operation() {
     local file_path="${2:-}"
 
     if [ "$TRACING_AVAILABLE" = true ] && is_tracing_enabled; then
-        TRACE_OPERATION_TYPE="$operation_type" TRACE_FILE_PATH="$file_path" python3 -c "
+        TRACE_OPERATION_TYPE="$operation_type" TRACE_FILE_PATH="$file_path" "$PYTHON_CMD" -c "
 import sys
 import os
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
@@ -166,7 +179,7 @@ trace_hub_sync() {
     local files_count="${2:-0}"
     
     if [ "$TRACING_AVAILABLE" = true ] && is_tracing_enabled; then
-        python3 -c "
+        "$PYTHON_CMD" -c "
 import sys
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
 from tracing import record_hub_sync
@@ -204,7 +217,7 @@ trace_event() {
     fi
 
     if [ "$TRACING_AVAILABLE" = true ] && is_tracing_enabled; then
-        TRACE_EVENT_NAME="$event_name" TRACE_EVENT_ATTRS="$attrs_json" python3 -c "
+        TRACE_EVENT_NAME="$event_name" TRACE_EVENT_ATTRS="$attrs_json" "$PYTHON_CMD" -c "
 import sys
 import os
 import json
@@ -228,7 +241,7 @@ trace_attribute() {
     local value="$2"
 
     if [ "$TRACING_AVAILABLE" = true ] && is_tracing_enabled; then
-        TRACE_KEY="$key" TRACE_VALUE="$value" python3 -c "
+        TRACE_KEY="$key" TRACE_VALUE="$value" "$PYTHON_CMD" -c "
 import sys
 import os
 sys.path.insert(0, '$TRACING_SCRIPT_DIR')
@@ -246,7 +259,7 @@ trace_status() {
         echo "Tracing module: Available"
         if is_tracing_enabled; then
             echo "Tracing status: Enabled"
-            python3 "$TRACING_PY" status 2>/dev/null || true
+            "$PYTHON_CMD" "$TRACING_PY" status 2>/dev/null || true
         else
             echo "Tracing status: Disabled"
         fi
@@ -258,7 +271,12 @@ trace_status() {
             echo "Reason: Tracing module not found at $TRACING_PY"
         else
             echo "Reason: Import error (missing dependencies?)"
-            echo "Install with: pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-instrumentation-subprocess"
+            echo ""
+            echo "Install dependencies with:"
+            echo "  ai-use-case tracing install-deps"
+            echo ""
+            echo "Or manually:"
+            echo "  $0 install-deps"
         fi
     fi
 }
@@ -308,25 +326,47 @@ enable_script_tracing() {
 # Function to install tracing dependencies
 install_tracing_deps() {
     echo "Installing OpenTelemetry dependencies (v1.20.0+)..."
+    echo "Using virtual environment at: $TRACING_VENV_DIR"
 
-    # Install with version constraints for compatibility
+    # Check if Python 3 is available
+    if ! command -v python3 &> /dev/null; then
+        echo "Error: python3 not found. Please install Python 3 and try again."
+        return 1
+    fi
+
+    # Create virtual environment if it doesn't exist
+    if [ ! -d "$TRACING_VENV_DIR" ]; then
+        echo "Creating virtual environment..."
+        mkdir -p "$(dirname "$TRACING_VENV_DIR")"
+        python3 -m venv "$TRACING_VENV_DIR" || {
+            echo "Error: Failed to create virtual environment."
+            echo "You may need to install python3-venv: sudo apt install python3-venv"
+            return 1
+        }
+        echo "Virtual environment created."
+    else
+        echo "Using existing virtual environment."
+    fi
+
+    # Install packages into the virtual environment
     local packages=(
         "opentelemetry-api>=1.20.0,<2.0.0"
         "opentelemetry-sdk>=1.20.0,<2.0.0"
         "opentelemetry-exporter-otlp>=1.20.0,<2.0.0"
-        "opentelemetry-instrumentation-subprocess>=0.41b0,<1.0.0"
     )
 
-    if command -v pip3 &> /dev/null; then
-        pip3 install --user "${packages[@]}"
-    elif command -v pip &> /dev/null; then
-        pip install --user "${packages[@]}"
-    else
-        echo "Error: pip not found. Please install pip and try again."
+    echo "Installing packages into virtual environment..."
+    "${TRACING_VENV_DIR}/bin/pip" install --upgrade pip >/dev/null 2>&1
+    "${TRACING_VENV_DIR}/bin/pip" install "${packages[@]}" || {
+        echo "Error: Failed to install packages."
         return 1
-    fi
+    }
 
-    echo "Dependencies installed. You may need to restart your shell."
+    echo ""
+    echo "Dependencies installed successfully!"
+    echo "Virtual environment location: $TRACING_VENV_DIR"
+    echo ""
+    echo "To customize the venv location, set: export AI_USECASE_VENV_DIR=/path/to/venv"
 }
 
 # Export functions for use in other scripts


### PR DESCRIPTION
## Summary

Fixes the installation failure of tracing dependencies on modern Debian/Ubuntu systems with PEP 668 externally-managed-environment protection. Changes from `pip3 install --user` to an isolated virtual environment approach.

## Problem

The `ai-use-case tracing install-deps` command was failing with:
```
error: externally-managed-environment
× This environment is externally managed
```

This occurs on modern Linux distributions (Ubuntu 23.04+, Debian 12+) that implement PEP 668 to prevent pip from modifying system Python packages.

## Solution

- **Virtual Environment Approach**: Create isolated venv at `~/.local/share/ai-use-case-cli/venv`
- **Automatic Python Selection**: Prefer venv Python, fallback to system Python
- **Customizable Location**: Support `AI_USECASE_VENV_DIR` environment variable
- **Removed Non-existent Package**: `opentelemetry-instrumentation-subprocess` doesn't exist in PyPI
- **Optional Instrumentation**: Made subprocess instrumentation optional in Python code

## Changes Made

### scripts/utils/tracing.sh
- Added `TRACING_VENV_DIR` and `TRACING_PYTHON` variables
- Updated `PYTHON_CMD` selection to prefer venv Python
- Rewrote `install_tracing_deps()` to create and use venv
- Replaced all `python3` calls with `"$PYTHON_CMD"`
- Removed non-existent `opentelemetry-instrumentation-subprocess` package
- Updated error messages to reference new installation method

### scripts/utils/tracing.py
- Made subprocess instrumentation optional (separate try/except)
- Added `SUBPROCESS_INSTRUMENTATION_AVAILABLE` flag
- Conditional usage of `SubprocessInstrumentor`

### CHANGELOG.md
- Documented the fix under `[Unreleased]` section

## Testing

```bash
# Clean test
rm -rf ~/.local/share/ai-use-case-cli/venv
bash scripts/utils/tracing.sh install-deps
# ✅ Successfully creates venv and installs packages

# Verify functionality
bash scripts/utils/tracing.sh status
# ✅ Tracing module: Available

bash scripts/utils/tracing.sh test
# ✅ Test completed
```

## Checklist

- [x] Created feature branch (`fix/tracing-venv-install`)
- [x] Updated CHANGELOG.md under `[Unreleased]`
- [x] Tested installation from scratch
- [x] Verified tracing functionality works
- [x] All Python invocations use venv
- [x] Documentation reviewed (no user-facing changes needed)
- [x] Conventional commit message used

## Related Issues

Resolves the "Method not allowed" curl confusion (that was actually expected behavior - OTLP endpoint only accepts POST).

The real issue was the Python dependency installation, which is now fully resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)