### PR TITLE
feat: add reset command for configuration management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Reset Command**: New `reset` command to safely clean CLI configuration and data
+  - Added `scripts/utils/reset.sh` with comprehensive safety features
+  - Selective reset options: `--config`, `--registry`, `--tracing`, `--hub`, `--all`
+  - Safety features: confirmation prompts, dry-run mode (`--dry-run`), force mode (`--force`)
+  - Special protection for git-based hubs (prevents accidental deletion)
+  - Displays file sizes and clear warnings before deletion
+  - Provides next steps after reset completion
+  - Usage: `ai-use-case reset --config` or `ai-use-case reset --all --dry-run`
+
 ### Fixed
 
 - **Tracing Dependency Installation**: Fixed installation failure on externally-managed Python environments

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Use **either** standalone CLI or Claude Code slash commands—whatever fits your
 | Check for updates | `ai-use-case check-updates` | `/use-case:check-updates` |
 | Update project | `ai-use-case update-project <path>` | `/use-case:update-project` |
 | Cleanup backups | `ai-use-case cleanup-backups [path]` | |
+| Reset configuration | `ai-use-case reset [options]` | |
 | Publish to Confluence | `ai-use-case publish-confluence` | `/use-case:publish-confluence` |
 | View hub | `ai-use-case view` | |
 | Push hub changes | `ai-use-case push` | |
@@ -314,6 +315,32 @@ chmod +x /path/to/project/.git/hooks/post-commit
 # Test manual sync
 ai-use-case sync
 ```
+
+### Reset configuration or data
+
+If you need to start fresh or fix configuration issues:
+
+```bash
+# Preview what would be reset (dry-run)
+ai-use-case reset --config --dry-run
+
+# Reset only configuration files
+ai-use-case reset --config
+
+# Reset tracing setup
+ai-use-case reset --tracing
+
+# Reset project registry
+ai-use-case reset --registry
+
+# Reset everything (prompts for confirmation)
+ai-use-case reset --all
+
+# See all options
+ai-use-case reset --help
+```
+
+**Note**: The hub directory is protected and requires explicit `--hub` flag to delete (only for local-only mode).
 
 ### Colors not rendering
 

--- a/ai-use-case
+++ b/ai-use-case
@@ -69,6 +69,7 @@ ${YELLOW}COMMANDS${NC}
   ${GREEN}publish-confluence${NC}        Publish use case to Confluence
   ${GREEN}cleanup-backups [path]${NC}    Remove backup files from project
   ${GREEN}tracing [subcommand]${NC}      Manage tracing configuration
+  ${GREEN}reset [options]${NC}           Reset CLI configuration and data
   ${GREEN}bump-version <type>${NC}       Bump version (major|minor|patch)
   ${GREEN}uninstall${NC}                 Uninstall the CLI tool
   ${GREEN}--version, -v, version${NC}    Show version information
@@ -383,6 +384,18 @@ EOF
         else
             trace_event "error" "command=tracing" "error=config_manager_not_found"
             echo -e "${RED}Error: config-manager.sh not found${NC}"
+            exit 1
+        fi
+        ;;
+    reset)
+        trace_event "command_start" "command=reset" "args=$*"
+        if [ -f "$SCRIPT_DIR/scripts/utils/reset.sh" ]; then
+            # Pass all arguments after the command to the script
+            shift
+            trace_run "reset" bash "$SCRIPT_DIR/scripts/utils/reset.sh" "$@"
+        else
+            trace_event "error" "command=reset" "error=script_not_found" "script=reset.sh"
+            echo -e "${RED}Error: reset.sh not found${NC}"
             exit 1
         fi
         ;;

--- a/scripts/utils/reset.sh
+++ b/scripts/utils/reset.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# AI Use Case CLI - Reset Configuration
+# Safely reset CLI configuration, registry, and cached data
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Configuration paths
+CONFIG_DIR="$HOME/.config/ai-use-case-cli"
+DATA_DIR="$HOME/.local/share/ai-use-case-cli"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+TRACING_CONFIG="$CONFIG_DIR/tracing.json"
+REGISTRY_FILE="$DATA_DIR/projects-registry.json"
+TRACING_VENV="$DATA_DIR/tracing-venv"
+HUB_DIR="$DATA_DIR/hub"
+
+# Flags
+RESET_ALL=false
+RESET_CONFIG=false
+RESET_REGISTRY=false
+RESET_TRACING=false
+RESET_HUB=false
+DRY_RUN=false
+FORCE=false
+
+# Parse arguments
+show_help() {
+    cat <<EOF
+${BLUE}AI Use Case CLI - Reset Configuration${NC}
+
+${YELLOW}Usage:${NC}
+  $0 [options]
+
+${YELLOW}Options:${NC}
+  ${GREEN}--all${NC}           Reset everything (config, registry, tracing, hub)
+                  ${RED}⚠ WARNING: This includes your hub data!${NC}
+
+  ${GREEN}--config${NC}        Reset only configuration files
+                  (config.json, tracing.json)
+
+  ${GREEN}--registry${NC}      Reset only projects registry
+                  (projects-registry.json)
+
+  ${GREEN}--tracing${NC}       Reset only tracing configuration and virtual environment
+                  (tracing.json, tracing-venv/)
+
+  ${GREEN}--hub${NC}           Reset hub directory
+                  ${RED}⚠ WARNING: This deletes all your documented use cases!${NC}
+                  Only affects local-only mode hubs
+
+  ${GREEN}--dry-run${NC}       Show what would be deleted without actually deleting
+
+  ${GREEN}--force, -y${NC}     Skip confirmation prompts
+
+  ${GREEN}--help, -h${NC}      Show this help message
+
+${YELLOW}Examples:${NC}
+  $0 --config              # Reset only configuration files
+  $0 --tracing             # Reset tracing setup
+  $0 --registry --config   # Reset registry and config
+  $0 --all --dry-run       # See what --all would delete
+  $0 --config --force      # Reset config without confirmation
+
+${YELLOW}Safety:${NC}
+  • All operations require confirmation unless --force is used
+  • Use --dry-run to preview changes before executing
+  • Hub data is only deleted if explicitly requested with --hub or --all
+  • Git-based hubs are never deleted (only local-only mode)
+
+${YELLOW}What Gets Reset:${NC}
+  Config:   $CONFIG_DIR/
+  Registry: $REGISTRY_FILE
+  Tracing:  $TRACING_CONFIG + $TRACING_VENV/
+  Hub:      $HUB_DIR/ (local-only mode only)
+
+EOF
+}
+
+# Parse flags
+if [ $# -eq 0 ]; then
+    show_help
+    exit 0
+fi
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --all)
+            RESET_ALL=true
+            shift
+            ;;
+        --config)
+            RESET_CONFIG=true
+            shift
+            ;;
+        --registry)
+            RESET_REGISTRY=true
+            shift
+            ;;
+        --tracing)
+            RESET_TRACING=true
+            shift
+            ;;
+        --hub)
+            RESET_HUB=true
+            shift
+            ;;
+        --dry-run|-n)
+            DRY_RUN=true
+            shift
+            ;;
+        --force|-y)
+            FORCE=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option '$1'${NC}"
+            echo "Run $0 --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# If --all is set, enable everything
+if [ "$RESET_ALL" = true ]; then
+    RESET_CONFIG=true
+    RESET_REGISTRY=true
+    RESET_TRACING=true
+    RESET_HUB=true
+fi
+
+# Check if at least one option is selected
+if [ "$RESET_CONFIG" = false ] && [ "$RESET_REGISTRY" = false ] && [ "$RESET_TRACING" = false ] && [ "$RESET_HUB" = false ]; then
+    echo -e "${RED}Error: No reset options specified${NC}"
+    echo "Run $0 --help for usage information"
+    exit 1
+fi
+
+# Collect items to reset
+ITEMS_TO_RESET=()
+ITEMS_DISPLAY=()
+
+if [ "$RESET_CONFIG" = true ]; then
+    if [ -f "$CONFIG_FILE" ]; then
+        ITEMS_TO_RESET+=("$CONFIG_FILE")
+        SIZE=$(du -sh "$CONFIG_FILE" 2>/dev/null | cut -f1 || echo "unknown")
+        ITEMS_DISPLAY+=("  ${CYAN}Config:${NC}   $CONFIG_FILE ($SIZE)")
+    fi
+    if [ -f "$TRACING_CONFIG" ] && [ "$RESET_TRACING" = false ]; then
+        ITEMS_TO_RESET+=("$TRACING_CONFIG")
+        SIZE=$(du -sh "$TRACING_CONFIG" 2>/dev/null | cut -f1 || echo "unknown")
+        ITEMS_DISPLAY+=("  ${CYAN}Tracing:${NC}  $TRACING_CONFIG ($SIZE)")
+    fi
+fi
+
+if [ "$RESET_REGISTRY" = true ] && [ -f "$REGISTRY_FILE" ]; then
+    ITEMS_TO_RESET+=("$REGISTRY_FILE")
+    SIZE=$(du -sh "$REGISTRY_FILE" 2>/dev/null | cut -f1 || echo "unknown")
+    ITEMS_DISPLAY+=("  ${CYAN}Registry:${NC} $REGISTRY_FILE ($SIZE)")
+fi
+
+if [ "$RESET_TRACING" = true ]; then
+    if [ -f "$TRACING_CONFIG" ]; then
+        ITEMS_TO_RESET+=("$TRACING_CONFIG")
+        SIZE=$(du -sh "$TRACING_CONFIG" 2>/dev/null | cut -f1 || echo "unknown")
+        ITEMS_DISPLAY+=("  ${CYAN}Tracing:${NC}  $TRACING_CONFIG ($SIZE)")
+    fi
+    if [ -d "$TRACING_VENV" ]; then
+        ITEMS_TO_RESET+=("$TRACING_VENV")
+        SIZE=$(du -sh "$TRACING_VENV" 2>/dev/null | cut -f1 || echo "unknown")
+        ITEMS_DISPLAY+=("  ${CYAN}Venv:${NC}     $TRACING_VENV/ ($SIZE)")
+    fi
+fi
+
+if [ "$RESET_HUB" = true ]; then
+    if [ -d "$HUB_DIR" ]; then
+        # Check if hub is git-based
+        if [ -d "$HUB_DIR/.git" ]; then
+            echo -e "${YELLOW}Warning: Hub appears to be a git repository${NC}"
+            echo "Path: $HUB_DIR"
+            echo ""
+            echo -e "${RED}Git-based hubs should NOT be deleted via reset!${NC}"
+            echo "Please manage your git repository manually."
+            echo ""
+            if [ "$FORCE" = false ]; then
+                read -p "Skip hub deletion and continue? [y/N] " -n 1 -r
+                echo ""
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    echo "Reset cancelled"
+                    exit 1
+                fi
+                RESET_HUB=false
+            else
+                echo "Skipping hub deletion (git repository detected)"
+                RESET_HUB=false
+            fi
+        else
+            ITEMS_TO_RESET+=("$HUB_DIR")
+            SIZE=$(du -sh "$HUB_DIR" 2>/dev/null | cut -f1 || echo "unknown")
+            ITEMS_DISPLAY+=("  ${RED}Hub:${NC}      $HUB_DIR/ ($SIZE) ${RED}[ALL USE CASES WILL BE DELETED!]${NC}")
+        fi
+    fi
+fi
+
+# Check if anything to delete
+if [ ${#ITEMS_TO_RESET[@]} -eq 0 ]; then
+    echo -e "${GREEN}✓${NC} Nothing to reset (specified items do not exist)"
+    exit 0
+fi
+
+# Display header
+echo -e "${BLUE}╭────────────────────────────────────────────────────────────╮${NC}"
+echo -e "${BLUE}│${NC} ${BOLD}AI Use Case CLI - Reset${NC}                                ${BLUE}│${NC}"
+echo -e "${BLUE}╰────────────────────────────────────────────────────────────╯${NC}"
+echo ""
+
+# Display items to reset
+echo -e "${YELLOW}The following will be deleted:${NC}"
+echo ""
+for item in "${ITEMS_DISPLAY[@]}"; do
+    echo -e "$item"
+done
+echo ""
+echo -e "Total items: ${BOLD}${#ITEMS_TO_RESET[@]}${NC}"
+echo ""
+
+# Special warning for hub deletion
+if [ "$RESET_HUB" = true ]; then
+    echo -e "${RED}╭────────────────────────────────────────────────────────────╮${NC}"
+    echo -e "${RED}│${NC} ${BOLD}⚠ WARNING: HUB DELETION${NC}                               ${RED}│${NC}"
+    echo -e "${RED}│${NC}                                                            ${RED}│${NC}"
+    echo -e "${RED}│${NC} This will permanently delete ALL your documented use      ${RED}│${NC}"
+    echo -e "${RED}│${NC} cases from the local hub. This cannot be undone!          ${RED}│${NC}"
+    echo -e "${RED}╰────────────────────────────────────────────────────────────╯${NC}"
+    echo ""
+fi
+
+# Dry run mode
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}[DRY RUN] No files will be deleted${NC}"
+    exit 0
+fi
+
+# Confirm deletion
+if [ "$FORCE" = false ]; then
+    if [ "$RESET_HUB" = true ]; then
+        echo -e "${RED}Type 'DELETE HUB' to confirm hub deletion:${NC}"
+        read -r CONFIRMATION
+        if [ "$CONFIRMATION" != "DELETE HUB" ]; then
+            echo "Reset cancelled"
+            exit 0
+        fi
+        echo ""
+    fi
+
+    read -p "Proceed with deletion? [y/N] " -n 1 -r
+    echo ""
+    echo ""
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Reset cancelled"
+        exit 0
+    fi
+else
+    echo -e "${YELLOW}Auto-confirming deletion (--force flag used)${NC}"
+    echo ""
+fi
+
+# Perform deletion
+DELETED_COUNT=0
+FAILED_COUNT=0
+
+for item in "${ITEMS_TO_RESET[@]}"; do
+    ITEM_NAME=$(basename "$item")
+
+    if [ -f "$item" ]; then
+        if rm -f "$item" 2>/dev/null; then
+            echo -e "${GREEN}✓${NC} Deleted file: $ITEM_NAME"
+            DELETED_COUNT=$((DELETED_COUNT + 1))
+        else
+            echo -e "${RED}✗${NC} Failed to delete: $ITEM_NAME"
+            FAILED_COUNT=$((FAILED_COUNT + 1))
+        fi
+    elif [ -d "$item" ]; then
+        if rm -rf "$item" 2>/dev/null; then
+            echo -e "${GREEN}✓${NC} Deleted directory: $ITEM_NAME/"
+            DELETED_COUNT=$((DELETED_COUNT + 1))
+        else
+            echo -e "${RED}✗${NC} Failed to delete: $ITEM_NAME/"
+            FAILED_COUNT=$((FAILED_COUNT + 1))
+        fi
+    fi
+done
+
+# Clean up empty directories
+if [ "$RESET_CONFIG" = true ] && [ -d "$CONFIG_DIR" ]; then
+    if [ -z "$(ls -A "$CONFIG_DIR" 2>/dev/null)" ]; then
+        rmdir "$CONFIG_DIR" 2>/dev/null || true
+    fi
+fi
+
+if [ -d "$DATA_DIR" ]; then
+    if [ -z "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
+        rmdir "$DATA_DIR" 2>/dev/null || true
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}╭────────────────────────────────────────────────────────────╮${NC}"
+echo -e "${GREEN}│${NC} ${BOLD}Reset Complete${NC}                                         ${GREEN}│${NC}"
+echo -e "${GREEN}╰────────────────────────────────────────────────────────────╯${NC}"
+echo ""
+echo -e "Successfully deleted: ${GREEN}$DELETED_COUNT${NC}"
+if [ $FAILED_COUNT -gt 0 ]; then
+    echo -e "Failed to delete:     ${RED}$FAILED_COUNT${NC}"
+fi
+echo ""
+
+# Show next steps
+echo -e "${CYAN}Next steps:${NC}"
+if [ "$RESET_CONFIG" = true ]; then
+    echo "  • Run ${GREEN}ai-use-case --init${NC} to setup a new project"
+    echo "  • Run ${GREEN}ai-use-case config reconfigure${NC} to setup hub again"
+fi
+if [ "$RESET_TRACING" = true ]; then
+    echo "  • Run ${GREEN}ai-use-case tracing configure${NC} to setup tracing again"
+    echo "  • Run ${GREEN}ai-use-case tracing install-deps${NC} to reinstall dependencies"
+fi
+if [ "$RESET_HUB" = true ]; then
+    echo "  • Run ${GREEN}ai-use-case config reconfigure${NC} to create a new hub"
+fi
+echo ""


### PR DESCRIPTION
## Summary

- **New reset command** for safely cleaning CLI configuration and data
- **Comprehensive safety features** including dry-run mode, confirmation prompts, and force mode
- **Selective reset options**: --config, --registry, --tracing, --hub, --all
- **Git-based hub protection** prevents accidental deletion of git repositories
- **User-friendly output** with file sizes, warnings, and next steps

## Changes

### Added
- `scripts/utils/reset.sh` - New reset script with comprehensive safety features
- Reset command integration in main CLI (`ai-use-case`)
- Documentation in README.md troubleshooting section
- CHANGELOG.md entry

### Features
- **Selective reset**: Choose what to reset (config, registry, tracing, hub, or all)
- **Dry-run mode**: Preview changes before executing (`--dry-run`)
- **Force mode**: Skip confirmation prompts (`--force`, `-y`)
- **Git protection**: Automatically detects and prevents deletion of git-based hubs
- **Clear warnings**: Special warnings for dangerous operations (hub deletion)
- **Next steps**: Provides guidance on what to do after reset

## Test Plan

- [x] Help documentation displays correctly
- [x] Dry-run mode shows what would be deleted
- [x] Config reset preview works
- [x] Registry reset preview works
- [x] All reset preview works with hub warning
- [x] Git-based hub protection (not tested live, but code implemented)
- [x] Updated CHANGELOG.md
- [x] Updated README.md

## Examples

```bash
# Preview what would be reset
ai-use-case reset --config --dry-run

# Reset only configuration files
ai-use-case reset --config

# Reset tracing setup
ai-use-case reset --tracing

# Reset everything (prompts for confirmation)
ai-use-case reset --all

# See all options
ai-use-case reset --help
```

## Documentation

- Command added to README.md in Core Commands table
- Troubleshooting section added with reset examples
- CHANGELOG.md updated with feature details

🤖 Generated with [Claude Code](https://claude.com/claude-code)