### PR TITLE
chore: add user data files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@ Thumbs.db
 # Backup directories
 .claude/backups/
 __pycache__/
+
+# User data files (created during CLI usage)
+projects-registry.json
+config.json
+tracing.json
+
+# Python virtual environment (created by tracing setup)
+venv/
+*.pyc


### PR DESCRIPTION
## Summary

Adds gitignore patterns for user-generated files that should not be tracked in the CLI repository.

## Problem

Users experience git conflicts when trying to update their CLI installation because user data files (projects-registry.json, venv/, config.json) are not gitignored.

Example error:
```
On branch main
Your branch is behind 'origin/main' by 14 commits
Untracked files:
    projects-registry.json
    venv/
```

## Solution

Add gitignore entries for:

**User Data Files:**
- `projects-registry.json` - User's local project registry
- `config.json` - Hub configuration
- `tracing.json` - Tracing configuration

**Python Environment:**
- `venv/` - Virtual environment created by tracing setup
- `*.pyc` - Python compiled files

## Impact

- Users can now `git pull` without conflicts from local data files
- User data remains private and local to each installation
- No data loss - files are just ignored, not deleted
- Aligns with standard gitignore practices

## Test Plan

- [x] Added gitignore entries
- [x] Verified patterns cover all user data files
- [ ] Test git pull with existing user data files (requires user testing)

No breaking changes - this is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)