### PR TITLE
fix: Clarify workflow todo list based on PR #92 feedback

### DIFF
--- a/.claude/commands/use-case/document-session.md
+++ b/.claude/commands/use-case/document-session.md
@@ -25,7 +25,7 @@ Before we start, here's the complete workflow you'll see:
 - [ ] Extract all relevant metrics and statistics
 
 **Phase 4: Information Extraction**
-- [ ] Calculate date with ISO 8601 week number
+- [ ] Calculate date with ISO 8601 week number for filename
 - [ ] Extract or generate appropriate ticket number
 - [ ] Determine complexity level from scope
 - [ ] Estimate time saved based on complexity
@@ -38,10 +38,10 @@ Before we start, here's the complete workflow you'll see:
 - [ ] Verify no TODO placeholders remain
 
 **Phase 6: Commit and Sync**
-- [ ] Add documentation file to git (if implementation session)
-- [ ] Create commit with proper attribution
-- [ ] Sync documentation to your hub
-- [ ] Confirm successful completion
+- [ ] Add documentation file to git (implementation sessions only)
+- [ ] Create commit with proper attribution (implementation sessions only)
+- [ ] Sync documentation to your hub (all session types)
+- [ ] Confirm successful completion (all session types)
 
 **Total time**: Usually 30-60 seconds after you select a session.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Provides estimated completion time (30-60 seconds)
   - Improves user understanding of what will happen
   - Makes automated workflow more transparent and predictable
+  - **Clarifications** (addressing PR #92 feedback):
+    - Phase 4: Clarified ISO 8601 week number is specifically for filename generation
+    - Phase 6: Explicitly labeled which steps apply to which session types (implementation vs research)
+    - Git commit steps only apply to implementation sessions
+    - Hub sync applies to all session types
 
 - **VERSION-UPDATE-CHECKLIST.md Enhancements**: Improved documentation to prevent version update mistakes
   - Added prominent warning at top about README.md footer being commonly forgotten


### PR DESCRIPTION
## Summary

Addresses PR review comments from copilot-pull-request-reviewer on PR #92 to improve clarity of the workflow todo list in the document-session command.

## Changes

### 1. Phase 4 - ISO 8601 Clarification
**Before**: `Calculate date with ISO 8601 week number`  
**After**: `Calculate date with ISO 8601 week number for filename`

**Rationale**: More specific about the purpose - it's for generating the filename in format `YYYY-Www-MM-DD_...`

### 2. Phase 6 - Session Type Specificity
**Before**:
- Add documentation file to git (if implementation session)
- Create commit with proper attribution
- Sync documentation to your hub
- Confirm successful completion

**After**:
- Add documentation file to git (implementation sessions only)
- Create commit with proper attribution (implementation sessions only)
- Sync documentation to your hub (all session types)
- Confirm successful completion (all session types)

**Rationale**: Clarifies that:
- Git operations (add/commit) only happen for implementation sessions
- Hub sync happens for ALL session types (implementation AND research)
- This matches the actual workflow documented in Step 8

### 3. Updated CHANGELOG.md
Added clarifications section documenting these improvements.

## Addresses PR Feedback

- ✅ [Comment #2](https://github.com/mt-osiris-tools/ai-use-case-cli/pull/92#discussion_r2525571884) - ISO 8601 clarification
- ✅ [Comment #3](https://github.com/mt-osiris-tools/ai-use-case-cli/pull/92#discussion_r2525571887) - Session type specificity

## Test Plan

- [x] Verified text changes match PR feedback suggestions
- [x] Confirmed CHANGELOG.md properly documents clarifications
- [x] Git hooks validation passed (version consistency check)
- [x] Changes improve clarity without changing functionality
- [x] Workflow description now matches Step 8 implementation details

## Files Changed

- `.claude/commands/use-case/document-session.md` - Clarified workflow steps
- `CHANGELOG.md` - Documented clarifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)