### PR TITLE
feat: Add HTML templates for Confluence publishing

### DIFF
--- a/templates/confluence/README.md
+++ b/templates/confluence/README.md
@@ -91,6 +91,13 @@ All templates support the following placeholders that will be replaced with actu
 
 ### Week Number in Title
 When processing a file named `2025-W45-11-08_DEMO-123_implement-feature.md`:
+
+> **Format Note:** The filename follows `YYYY-Www-MM-DD_TICKET-XXX_description.md` where:
+> - `YYYY` = Year (2025)
+> - `Www` = Week number (W45 = week 45)
+> - `MM-DD` = Calendar date (11-08 = November 8th)
+> - The `MM-DD` represents the actual calendar date that falls within the specified week
+
 1. The processor extracts week "W45" from the filename
 2. Converts it to "Week 45" for display
 3. Generates PAGE_TITLE as "Week 45 | DEMO-123: Implement Feature"
@@ -102,24 +109,33 @@ When processing a file named `2025-W45-11-08_DEMO-123_implement-feature.md`:
 <h1>🎯 Week 45 | DEMO-123: Implement Feature</h1>
 ```
 
-### Basic Replacement
-```javascript
-const template = fs.readFileSync('use-case-template.html', 'utf8');
-const html = template
-  .replace('{{PAGE_TITLE}}', 'Week 45 | LSFB-123: Feature Implementation')
-  .replace('{{WEEK_NUMBER}}', 'Week 45')
-  .replace('{{DATE}}', '2025-11-09')
-  .replace('{{TICKET_ID}}', 'LSFB-123');
+### Basic Command Line Usage
+```bash
+# Using the process-template.sh script (recommended)
+./process-template.sh 2025-W45-11-08_LSFB-123_feature-implementation.md > output.html
+
+# With the rich template
+./process-template.sh --rich 2025-W45-11-08_LSFB-123_feature-implementation.md > output.html
+
+# Save to specific file
+./process-template.sh -o confluence.html 2025-W45-11-08_LSFB-123_feature-implementation.md
 ```
 
 ### Conditional Sections
-Templates support conditional rendering using Handlebars-style syntax:
+Templates support conditional rendering using Handlebars-style syntax. The processor will:
+- Remove the entire `{{#if}}` block (including markers and content) if the variable is empty
+- Remove only the conditional markers (`{{#if}}` and `{{/if}}`) if the variable has content, keeping the content
+
 ```html
 {{#if CODE_EXAMPLES}}
 <h2>Code Examples</h2>
 <pre>{{CODE_EXAMPLES}}</pre>
 {{/if}}
 ```
+
+**Behavior:**
+- If `CODE_EXAMPLES` is empty → entire block is removed
+- If `CODE_EXAMPLES` has content → markers removed, content and heading remain
 
 ### Table Rows Example
 For `{{CHALLENGES_TABLE_ROWS}}`:

--- a/templates/confluence/process-template.sh
+++ b/templates/confluence/process-template.sh
@@ -86,8 +86,9 @@ extract_filename_metadata() {
         export DATE="$YEAR-$MONTH-$DAY"
 
         # Convert slug to title (replace hyphens with spaces, capitalize)
+        # Use awk for portability across BSD/GNU sed
         local title
-        title=$(echo "$SLUG" | tr '-' ' ' | sed 's/\b\(.\)/\u\1/g')
+        title=$(echo "$SLUG" | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
         export DESCRIPTION="$title"
 
         return 0
@@ -163,7 +164,14 @@ generate_defaults() {
     export TIMELINE_ITEMS="${TIMELINE_ITEMS:-}"  # Empty by default for conditional sections
 
     # System info
-    export CLI_VERSION="${CLI_VERSION:-3.9.1}"
+    # Source version from central location
+    SCRIPT_BASE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    if [ -f "$SCRIPT_BASE_DIR/scripts/utils/version.sh" ]; then
+        source "$SCRIPT_BASE_DIR/scripts/utils/version.sh"
+        export CLI_VERSION="${VERSION}"
+    else
+        export CLI_VERSION="${CLI_VERSION:-unknown}"
+    fi
     export LAST_UPDATED="${LAST_UPDATED:-$(date +'%Y-%m-%d %H:%M:%S')}"
     export CODE_LANGUAGE="${CODE_LANGUAGE:-bash}"
 }
@@ -225,16 +233,33 @@ process_template() {
     template_content="${template_content//\{\{CLI_VERSION\}\}/$CLI_VERSION}"
     template_content="${template_content//\{\{LAST_UPDATED\}\}/$LAST_UPDATED}"
 
-    # Original markdown (escape for HTML)
+    # Original markdown (escape for HTML with proper handling of all special characters)
     local escaped_markdown
-    escaped_markdown=$(echo "$ORIGINAL_MARKDOWN" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+    escaped_markdown=$(printf '%s\n' "$ORIGINAL_MARKDOWN" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'\''/\&#39;/g')
     template_content="${template_content//\{\{ORIGINAL_MARKDOWN\}\}/$escaped_markdown}"
 
-    # Handle conditional sections (simple implementation)
-    # Remove {{#if}} blocks where variable is empty
-    template_content=$(echo "$template_content" | sed '/{{#if CODE_EXAMPLES}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
-    template_content=$(echo "$template_content" | sed '/{{#if TIMELINE_ITEMS}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
-    template_content=$(echo "$template_content" | sed '/{{#if ATTACHMENTS}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
+    # Handle conditional sections properly
+    # Remove {{#if}} blocks only if variable is empty; otherwise, remove just the markers
+    if [[ -z "$CODE_EXAMPLES" ]]; then
+        template_content=$(echo "$template_content" | sed '/{{#if CODE_EXAMPLES}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
+    else
+        template_content="${template_content//\{\{#if CODE_EXAMPLES\}\}/}"
+        template_content="${template_content//\{\{\/if\}\}/}"
+    fi
+
+    if [[ -z "$TIMELINE_ITEMS" ]]; then
+        template_content=$(echo "$template_content" | sed '/{{#if TIMELINE_ITEMS}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
+    else
+        template_content="${template_content//\{\{#if TIMELINE_ITEMS\}\}/}"
+        template_content="${template_content//\{\{\/if\}\}/}"
+    fi
+
+    if [[ -z "$ATTACHMENTS" ]]; then
+        template_content=$(echo "$template_content" | sed '/{{#if ATTACHMENTS}}/,/{{\/if}}/d' 2>/dev/null || echo "$template_content")
+    else
+        template_content="${template_content//\{\{#if ATTACHMENTS\}\}/}"
+        template_content="${template_content//\{\{\/if\}\}/}"
+    fi
 
     # Output
     if [[ "$output" == "-" ]]; then
@@ -257,10 +282,16 @@ main() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             -t|--template)
+                if [[ -z "${2:-}" ]] || [[ "$2" == -* ]]; then
+                    error "Option --template requires an argument"
+                fi
                 template_file="$2"
                 shift 2
                 ;;
             -o|--output)
+                if [[ -z "${2:-}" ]] || [[ "$2" == -* ]]; then
+                    error "Option --output requires an argument"
+                fi
                 output_file="$2"
                 shift 2
                 ;;
@@ -269,6 +300,9 @@ main() {
                 shift
                 ;;
             -m|--metadata)
+                if [[ -z "${2:-}" ]] || [[ "$2" == -* ]]; then
+                    error "Option --metadata requires an argument"
+                fi
                 metadata_file="$2"
                 shift 2
                 ;;
@@ -313,9 +347,14 @@ main() {
     # Load additional metadata if provided
     if [[ -n "$metadata_file" ]] && [[ -f "$metadata_file" ]]; then
         info "Loading metadata from: $metadata_file"
-        # Source JSON metadata (basic implementation)
-        # In production, use jq or proper JSON parser
-        source "$metadata_file" 2>/dev/null || true
+        # Parse JSON metadata safely using jq
+        if command -v jq >/dev/null 2>&1; then
+            while IFS='=' read -r key value; do
+                [[ -n "$key" ]] && export "$key=$value"
+            done < <(jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' "$metadata_file" 2>/dev/null || true)
+        else
+            error "jq is required to parse JSON metadata files. Install with: apt-get install jq (Debian/Ubuntu) or brew install jq (macOS)"
+        fi
     fi
 
     # Generate defaults for missing values

--- a/templates/confluence/use-case-template-simple.html
+++ b/templates/confluence/use-case-template-simple.html
@@ -91,9 +91,9 @@
     <table>
         <thead>
             <tr>
-                <th>Challenge</th>
-                <th>Solution</th>
-                <th>AI Contribution</th>
+                <th scope="col">Challenge</th>
+                <th scope="col">Solution</th>
+                <th scope="col">AI Contribution</th>
             </tr>
         </thead>
         <tbody>

--- a/templates/confluence/use-case-template.html
+++ b/templates/confluence/use-case-template.html
@@ -83,11 +83,11 @@
         }
         .status-completed {
             background: #c6f6d5;
-            color: #22543d;
+            color: #1a472a; /* Darker for better contrast (WCAG AA) */
         }
         .status-in-progress {
             background: #fed7d7;
-            color: #742a2a;
+            color: #6b1f1f; /* Darker for better contrast (WCAG AA) */
         }
         .timeline-item {
             border-left: 2px solid #cbd5e0;
@@ -134,7 +134,7 @@
         <div class="metadata-item">
             <strong style="color: #718096; font-size: 0.85em;">Status</strong>
             <div style="margin-top: 4px;">
-                <span class="status-indicator status-{{STATUS_CLASS}}">{{STATUS}}</span>
+                <span class="status-indicator status-{{STATUS_CLASS}}" role="status" aria-label="Status">{{STATUS}}</span>
             </div>
         </div>
     </div>
@@ -178,12 +178,12 @@
 
     <!-- Challenges & Solutions -->
     <h2 class="section-header">🔧 Challenges & Solutions</h2>
-    <table style="width: 100%; border-collapse: collapse; margin: 15px 0;">
+    <table role="table" aria-label="Challenges and Solutions" style="width: 100%; border-collapse: collapse; margin: 15px 0;">
         <thead>
             <tr style="background: #edf2f7;">
-                <th style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">Challenge</th>
-                <th style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">Solution</th>
-                <th style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">AI Assistance</th>
+                <th scope="col" style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">Challenge</th>
+                <th scope="col" style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">Solution</th>
+                <th scope="col" style="padding: 10px; text-align: left; border: 1px solid #e2e8f0;">AI Assistance</th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- Add comprehensive HTML template system for formatting AI use case documentation for Confluence
- Provide both rich (modern styling) and simple (Confluence native) template options
- Include template processor script for automated markdown-to-HTML conversion

## Changes

### New Files Added (4 files, 1053 lines)
1. **`templates/confluence/use-case-template.html`** (292 lines)
   - Rich, visually appealing template with modern CSS styling
   - Features gradient headers, metadata grids, status indicators
   - Best for Cloud Confluence instances

2. **`templates/confluence/use-case-template-simple.html`** (181 lines)
   - Simplified template using native Confluence macros
   - Compatible with Server and Data Center instances
   - Uses Confluence storage format

3. **`templates/confluence/process-template.sh`** (350 lines)
   - Bash script for processing markdown files with templates
   - Extracts metadata from standard filename convention
   - Replaces 40+ placeholders with actual content
   - Supports dry-run mode and template selection

4. **`templates/confluence/README.md`** (230 lines)
   - Comprehensive documentation for templates
   - Complete placeholder reference guide
   - Usage examples and integration instructions

## Key Features

### Template Capabilities
- **40+ dynamic placeholders** for content replacement
- Automatic metadata extraction from filename (week, ticket, date)
- Support for conditional sections
- Code syntax highlighting
- Status indicators and metrics dashboard
- AI tools showcase section
- Timeline visualization support

### Template Processor Features
- Extract metadata from standard filename format (YYYY-Www-MM-DD_TICKET-XXX_description.md)
- Parse markdown content into sections
- Replace placeholders with actual values
- Support for both templates via flags (--rich for rich template)
- Dry-run mode for testing (--dry-run)
- JSON metadata override support

### Week Number Integration
- Automatically extracts week from filename (e.g., W45 → "Week 45")
- Includes week in page title: "Week 45 | TICKET-123: Description"
- Consistent across both templates

## Usage Examples

```bash
# Process with simple template (default)
./templates/confluence/process-template.sh case.md > output.html

# Use rich template
./templates/confluence/process-template.sh --rich case.md

# Preview metadata extraction
./templates/confluence/process-template.sh --dry-run case.md

# Save to file
./templates/confluence/process-template.sh -o confluence.html case.md
```

## Testing
- ✅ Tested template processor with sample files
- ✅ Verified week number appears in titles
- ✅ Confirmed all placeholders are handled
- ✅ Both templates generate valid HTML
- ✅ Version validation passed

## Next Steps
After merging, the templates can be integrated with the existing `publish-confluence.sh` script to provide formatted HTML output for Confluence publishing.

## Test Plan
- [ ] Clone branch and navigate to templates/confluence/
- [ ] Create a test markdown file following naming convention
- [ ] Run `./process-template.sh --dry-run <file>` to test metadata extraction
- [ ] Generate HTML with both templates and verify output
- [ ] Confirm week number appears in page titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)