### PR TITLE
fix: include year in Confluence page titles

### DIFF
--- a/.claude/commands/use-case/publish-confluence.md
+++ b/.claude/commands/use-case/publish-confluence.md
@@ -43,10 +43,10 @@ Use regex to extract:
 Read the markdown file and determine the page title:
 
 **Title extraction from filename** (e.g., `2025-W42-10-16_PROJ-123_implement-auth.md`):
-1. Remove date prefix: `2025-W42-10-16_`
+1. Extract year and week: `2025` and `W42`
 2. Extract ticket: `PROJ-123`
 3. Convert slug to title: `implement-auth` → `Implement Auth`
-4. Format: `PROJ-123: Implement Auth`
+4. Format: `🎯 2025 W42 | PROJ-123: Implement Auth`
 
 **Alternative**: User can provide custom title via `--title` parameter.
 
@@ -138,8 +138,8 @@ Display results to the user:
 ```
 ✅ Successfully published to Confluence!
 
-Page Title: PROJ-123: Implement Auth
-Page URL: https://mycompany.atlassian.net/wiki/spaces/DOCS/pages/987654321/PROJ-123+Implement+Auth
+Page Title: 🎯 2025 W42 | PROJ-123: Implement Auth
+Page URL: https://mycompany.atlassian.net/wiki/spaces/DOCS/pages/987654321/2025+W42+PROJ-123+Implement+Auth
 
 Parent Page: AI Use Cases Documentation
 Space: DOCS
@@ -234,7 +234,7 @@ When `--dry-run` is specified, show what would be published without actually doi
 
 Source File: .usecase/cases/2025-W42-10-16_PROJ-123_implement-auth.md
 File Size: 15.3 KB
-Page Title: PROJ-123: Implement Auth
+Page Title: 🎯 2025 W42 | PROJ-123: Implement Auth
 
 Target:
 - Parent Page ID: 123456789
@@ -244,7 +244,7 @@ Target:
 
 Content Preview:
 ================================================================================
-# PROJ-123: Implement Auth
+# 🎯 2025 W42 | PROJ-123: Implement Auth
 
 ## Metadata
 - Date: 2025-W42-10-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Confluence Title Format**: Include year in Confluence page titles
+  - Updated `/publish-confluence` slash command to format titles as `🎯 2025 W## | TICKET-ID: Title`
+  - Fixed `publish-confluence.sh` to capture and include year in title extraction
+  - Fixed `process-template.sh` to include year in `WEEK_NUMBER` variable
+  - Ensures published Confluence pages show the full year and week for better organization
+
 ## [3.10.0] - 2025-12-01
 
 ### Added

--- a/scripts/core/publish-confluence.sh
+++ b/scripts/core/publish-confluence.sh
@@ -163,17 +163,17 @@ extract_title() {
     local filename=$(basename "$MARKDOWN_FILE" .md)
 
     # Pattern: YYYY-Www-MM-DD_TICKET-XXX_description-slug
-    if [[ $filename =~ ^[0-9]{4}-(W[0-9]{2})-[0-9]{2}-[0-9]{2}_([A-Z]+-[0-9]+)_(.+)$ ]]; then
-        local week="${BASH_REMATCH[1]}"  # W45
-        local ticket="${BASH_REMATCH[2]}"  # LSFB-63590
-        local slug="${BASH_REMATCH[3]}"  # description-slug
+    if [[ $filename =~ ^([0-9]{4})-(W[0-9]{2})-[0-9]{2}-[0-9]{2}_([A-Z]+-[0-9]+)_(.+)$ ]]; then
+        local year="${BASH_REMATCH[1]}"  # 2025
+        local week="${BASH_REMATCH[2]}"  # W45
+        local ticket="${BASH_REMATCH[3]}"  # FEATURE-001
+        local slug="${BASH_REMATCH[4]}"  # description-slug
 
         # Convert slug to title case
         local title=$(echo "$slug" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')
 
-        # Format: 🎯 Week 45 | TICKET-ID: Title
-        local week_number="${week#W}"  # Remove W prefix: 45
-        echo "🎯 Week ${week_number} | ${ticket}: ${title}"
+        # Format: 🎯 2025 W45 | TICKET-ID: Title
+        echo "🎯 ${year} ${week} | ${ticket}: ${title}"
     else
         # Fallback: just use filename with underscores converted to spaces
         echo "$filename" | sed 's/_/ /g'

--- a/templates/confluence/process-template.sh
+++ b/templates/confluence/process-template.sh
@@ -82,7 +82,7 @@ extract_filename_metadata() {
         export SLUG="${BASH_REMATCH[6]}"
 
         # Format values
-        export WEEK_NUMBER="Week ${WEEK#W}"
+        export WEEK_NUMBER="${YEAR} ${WEEK}"
         export DATE="$YEAR-$MONTH-$DAY"
 
         # Convert slug to title (replace hyphens with spaces, capitalize)
@@ -132,7 +132,7 @@ extract_markdown_sections() {
 generate_defaults() {
     # Page metadata defaults
     export PAGE_EMOJI="${PAGE_EMOJI:-🎯}"
-    export PAGE_TITLE="${PAGE_TITLE:-$WEEK_NUMBER | $TICKET_ID: $DESCRIPTION}"
+    export PAGE_TITLE="${PAGE_TITLE:-🎯 $WEEK_NUMBER | $TICKET_ID: $DESCRIPTION}"
     export PAGE_DESCRIPTION="${PAGE_DESCRIPTION:-AI-assisted development use case documentation}"
     export STATUS="${STATUS:-Completed}"
     export STATUS_COLOR="${STATUS_COLOR:-Green}"


### PR DESCRIPTION
## Summary

Fixes Confluence page titles to include the year along with the week number, ensuring better organization and clarity.

**Before:** `FEATURE-001: Claude Agent Usage Tracking Implementation`  
**After:** `🎯 2025 W49 | FEATURE-001: Claude Agent Usage Tracking Implementation`

## Problem

When publishing AI use case documentation to Confluence, the page titles were missing the year and week information, making it difficult to organize and identify when cases were created. The title extraction logic was:
1. Not capturing the year from the filename
2. Only showing week number without context
3. Missing the emoji prefix in slash command

## Solution

Updated three locations where titles are generated:

1. **`.claude/commands/use-case/publish-confluence.md`**
   - Updated slash command instructions to format as `🎯 YYYY W## | TICKET-ID: Title`
   - Updated all example outputs to show new format

2. **`scripts/core/publish-confluence.sh`**
   - Fixed regex pattern to capture year: `^([0-9]{4})-(W[0-9]{2})-...`
   - Updated format string to include year and week: `🎯 ${year} ${week} | ${ticket}: ${title}`

3. **`templates/confluence/process-template.sh`**
   - Updated `WEEK_NUMBER` variable to include year: `"${YEAR} ${WEEK}"`
   - Added emoji to `PAGE_TITLE` default format

## Testing

Tested title extraction with sample filename:
```bash
Input:  2025-W49-12-01_FEATURE-001_claude-agent-usage-tracking.md
Output: 🎯 2025 W49 | FEATURE-001: Claude Agent Usage Tracking
```

✅ All version validation checks passed

## Changes

- 4 files changed
- 23 insertions, 15 deletions
- All changes are backward compatible (existing pages unaffected)

## Impact

- **Better organization**: Confluence pages now show year and week for easy chronological sorting
- **Improved clarity**: Full context visible in page title without opening the page
- **Consistent format**: All three title generation methods now produce the same format

🤖 Generated with [Claude Code](https://claude.com/claude-code)