### PR TITLE
fix: simplify .gitignore pattern to .usecase/ directory

### DIFF
--- a/scripts/project/setup-project.sh
+++ b/scripts/project/setup-project.sh
@@ -628,8 +628,8 @@ if [ -f "$GITIGNORE" ]; then
     if ! grep -q "^# Use Case Documentation" "$GITIGNORE"; then
         echo "" >> "$GITIGNORE"
         echo "# Use Case Documentation" >> "$GITIGNORE"
-        echo ".usecase/cases/" >> "$GITIGNORE"
-        echo -e "${GREEN}✓${NC} Added .usecase/cases/ to .gitignore"
+        echo ".usecase/" >> "$GITIGNORE"
+        echo -e "${GREEN}✓${NC} Added .usecase/ to .gitignore"
     else
         echo -e "${YELLOW}⚠${NC} .gitignore already configured"
     fi


### PR DESCRIPTION
## Summary

Simplified the `.gitignore` pattern from `.usecase/cases/` to `.usecase/` to ignore the entire `.usecase/` directory.

## Changes

- Updated `scripts/project/setup-project.sh` to use `.usecase/` pattern instead of `.usecase/cases/`
- This ensures both `cases/` and `session-stats/` subdirectories are ignored

## Benefits

1. **Simpler pattern**: Single directory pattern instead of subdirectory-specific
2. **More comprehensive**: Covers all subdirectories under `.usecase/` including:
   - `.usecase/cases/` (use case documentation)
   - `.usecase/session-stats/` (session statistics)
3. **Future-proof**: Any new subdirectories will be automatically ignored

## Testing

- Verified the change in setup-project.sh
- Pattern follows standard gitignore conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)