### PR TITLE
fix: resolve unbound variable errors in scripts with set -u

### DIFF
--- a/scripts/core/document-ai-session.sh
+++ b/scripts/core/document-ai-session.sh
@@ -171,7 +171,7 @@ ensure_hub_exists() {
     local default_hub="$HOME/.local/share/ai-use-case-cli/hub"
 
     # Check if AI_USECASES_DIR is set
-    if [ -n "$AI_USECASES_DIR" ]; then
+    if [ -n "${AI_USECASES_DIR:-}" ]; then
         hub_dir="$AI_USECASES_DIR"
     else
         hub_dir="$default_hub"

--- a/scripts/project/list-projects.sh
+++ b/scripts/project/list-projects.sh
@@ -24,7 +24,7 @@ ensure_hub_exists() {
     local default_hub="$HOME/.local/share/ai-use-case-cli/hub"
 
     # Check if AI_USECASES_DIR is set
-    if [ -n "$AI_USECASES_DIR" ]; then
+    if [ -n "${AI_USECASES_DIR:-}" ]; then
         hub_dir="$AI_USECASES_DIR"
     else
         hub_dir="$default_hub"

--- a/scripts/project/setup-project.sh
+++ b/scripts/project/setup-project.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 

--- a/scripts/utils/config-manager.sh
+++ b/scripts/utils/config-manager.sh
@@ -186,7 +186,7 @@ get_hub_mode() {
 # Get hub path
 get_hub_path() {
     # Check environment variable first (highest priority)
-    if [ -n "$AI_USECASES_DIR" ]; then
+    if [ -n "${AI_USECASES_DIR:-}" ]; then
         echo "$AI_USECASES_DIR"
         return 0
     fi


### PR DESCRIPTION
## Summary
- Fixed AI_USECASES_DIR unbound variable error in multiple scripts
- Added missing CYAN color variable in setup-project.sh
- Applied consistent safe variable checking across all affected scripts

## Problem
When running `ai-use-case init`, the command failed with two unbound variable errors:

1. `AI_USECASES_DIR: unbound variable` in config-manager.sh line 189
2. `CYAN: unbound variable` in setup-project.sh line 412

The root cause was that scripts using `set -euo pipefail` would fail when referencing unset variables, even inside conditional checks like `[ -n "$VAR" ]`.

## Solution

### 1. AI_USECASES_DIR variable handling
Changed unsafe variable checks from:
```bash
if [ -n "$AI_USECASES_DIR" ]; then
```

To safe parameter expansion:
```bash
if [ -n "${AI_USECASES_DIR:-}" ]; then
```

Applied this fix to:
- scripts/utils/config-manager.sh (critical - sourced by setup-project.sh)
- scripts/core/document-ai-session.sh (consistency)
- scripts/project/list-projects.sh (consistency)

### 2. CYAN color variable
Added missing color definition in setup-project.sh:
```bash
CYAN='\033[0;36m'
```

## Test plan
- [x] Tested `ai-use-case init` in a clean directory
- [x] Verified no unbound variable errors occur
- [x] Confirmed all setup steps complete successfully
- [x] Verified color output displays correctly

## Files changed
- scripts/utils/config-manager.sh
- scripts/project/setup-project.sh  
- scripts/core/document-ai-session.sh
- scripts/project/list-projects.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)