### PR TITLE
docs: Address Copilot review feedback - clarify Codex init-only behavior

### DIFF
--- a/scripts/project/setup-project.sh
+++ b/scripts/project/setup-project.sh
@@ -484,7 +484,11 @@ else
     echo -e "${YELLOW}⚠${NC} AI tool commands not found in CLI installation"
 fi
 
-# Setup Codex integration (if Codex was selected)
+# Setup Codex integration (if Codex was selected, init mode only)
+# NOTE: Unlike Claude Code integration (which runs in both init and update modes to maintain
+# project-specific symlink structure), Codex setup is intentionally init-only because it's a
+# one-time global setup (installs prompts to ~/.codex/prompts/). Users who need to add or update
+# Codex integration later can run: ai-use-case --setup-codex
 if [[ "$SELECTED_AGENTS" == *"codex"* ]] && [ "$UPDATE_MODE" = false ]; then
     echo ""
     echo -e "${BLUE}Setting up Codex integration...${NC}"


### PR DESCRIPTION
## Summary

Addresses Copilot review feedback on PR #175 by adding explanatory comments for the intentional design difference between Claude Code and Codex integration setup behavior.

## Changes

### Modified Files
- **scripts/project/setup-project.sh** (line 487-492)
  - Added detailed comment explaining why Codex setup is init-only while Claude Code setup runs in both init and update modes

## Context

Copilot reviewer noted an inconsistency:
- Claude Code integration: runs in both init and update modes (`|| [ "$UPDATE_MODE" = true ]`)
- Codex integration: only runs during init mode (`&& [ "$UPDATE_MODE" = false ]`)

## Clarification

This behavior is **intentional** and now documented:

- **Claude Code Integration**: 
  - Runs in both init and update modes
  - Manages project-specific symlink structure (`.claude/commands/use-case`)
  - Needs to run on updates to maintain/verify project configuration

- **Codex Integration**:
  - Init-only (one-time setup)
  - Installs prompts globally to `~/.codex/prompts/`
  - Doesn't need to run on every update
  - Users can add/update later via: `ai-use-case --setup-codex`

## Benefits

- ✅ Addresses Copilot PR review feedback
- ✅ Clarifies intentional design decision
- ✅ Documents the distinction between project-specific and global setup
- ✅ Provides guidance for users who need to add Codex later

## Resolves

- Copilot review comment on PR #175 (discussion_r2617842615)

🤖 Generated with [Claude Code](https://claude.com/claude-code)