### PR TITLE
docs: prefer XDG_CONFIG_HOME in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **XDG Config Directory**: Honor `XDG_CONFIG_HOME` for configuration files instead of always using `~/.config`
 
+- **Docs XDG Paths**: Updated documentation to prefer `$XDG_CONFIG_HOME/ai-use-case-cli/*` paths with `$HOME/.config` defaults (instead of hardcoding `~/.config`)
+
 - **Codex Prompt Parameter Parsing**: Fixed internal bash variables appearing as user-facing parameters in Codex CLI
   - Changed parameter references in documentation from `$UPPERCASE` to `UPPERCASE` (removed $ prefix) to prevent Codex from displaying them as parameters
   - Changed internal bash variables in code blocks from `$UPPERCASE` to lowercase with `$` prefix (e.g., `$USER_EMAIL` → `$user_email`)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -118,7 +118,7 @@ ai-use-case tracing set <key> <value>
 ```
 
 **Configuration:**
-- Config file: `$XDG_CONFIG_HOME/ai-use-case-cli/tracing.json` (default: `~/.config/ai-use-case-cli/tracing.json`)
+- Config file: `$XDG_CONFIG_HOME/ai-use-case-cli/tracing.json` (default: `$HOME/.config/ai-use-case-cli/tracing.json`)
 - Environment variables: `AI_USECASE_TRACING_ENABLED`, `AI_USECASE_TRACING_ENDPOINT`, `AI_USECASE_TRACING_SAMPLING`
 - See [docs/TRACING.md](TRACING.md) for complete guide
 
@@ -178,7 +178,7 @@ ai-use-case analyze-patterns --format json
 ```
 
 **Agent Configuration:**
-- Registry file: `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `~/.config/ai-use-case-cli/agents.json`)
+- Registry file: `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - Cache directory: `~/.cache/ai-use-case-cli/agents/`
 - See [docs/agents/framework/README.md](agents/framework/README.md) for complete guide
 

--- a/docs/CONFLUENCE-INTEGRATION.md
+++ b/docs/CONFLUENCE-INTEGRATION.md
@@ -77,7 +77,7 @@ The AI assistant will automatically handle the publishing using MCP tools.
 
 ### Method 1: Configuration File (Persistent)
 
-Store credentials in `~/.config/ai-use-case-cli/config.json`:
+Store credentials in `$XDG_CONFIG_HOME/ai-use-case-cli/config.json` (default: `$HOME/.config/ai-use-case-cli/config.json`):
 
 ```bash
 ai-use-case config confluence
@@ -278,12 +278,12 @@ The CLI automatically sets secure permissions:
 
 ```bash
 # Config file permissions (owner read/write only)
-chmod 600 ~/.config/ai-use-case-cli/config.json
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/config.json"
 ```
 
 **Check permissions:**
 ```bash
-ls -la ~/.config/ai-use-case-cli/config.json
+ls -la "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/config.json"
 # Should show: -rw------- (600)
 ```
 
@@ -296,7 +296,7 @@ To update your API token:
 ai-use-case config confluence
 
 # Or manually edit config
-vim ~/.config/ai-use-case-cli/config.json
+vim "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/config.json"
 ```
 
 ### Revoking Access
@@ -366,7 +366,7 @@ ai-use-case publish-confluence \
 
 **Reset configuration:**
 ```bash
-rm ~/.config/ai-use-case-cli/config.json
+rm "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/config.json"
 ai-use-case config confluence
 ```
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -54,7 +54,7 @@ ai-use-case tracing test
 
 ### Configuration File
 
-Location: `~/.config/ai-use-case-cli/tracing.json`
+Location: `$XDG_CONFIG_HOME/ai-use-case-cli/tracing.json` (default: `$HOME/.config/ai-use-case-cli/tracing.json`)
 
 ```json
 {
@@ -388,7 +388,7 @@ When upgrading the CLI:
 
 - Check troubleshooting section above
 - Use `ai-use-case tracing status` for diagnostic information
-- Review logs in `~/.config/ai-use-case-cli/`
+- Review logs in `$XDG_CONFIG_HOME/ai-use-case-cli/` (default: `$HOME/.config/ai-use-case-cli/`)
 
 ### Feature Requests
 

--- a/docs/agents/claude/README.md
+++ b/docs/agents/claude/README.md
@@ -181,7 +181,7 @@ ls -la .claude/commands/use-case    # Should show symlink → ../../.ai-tools/co
 
 **System files:**
 - `~/.local/share/ai-use-case-cli/projects-registry.json` - Project registry (v3.1.0+)
-- `~/.config/ai-use-case-cli/config.json` - Hub configuration (v3.2.0+)
+- `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/config.json` - Hub configuration (v3.2.0+)
 
 ## Hub Configuration (v3.2.0+)
 

--- a/docs/agents/framework/README.md
+++ b/docs/agents/framework/README.md
@@ -425,12 +425,20 @@ ai-use-case agents reset
 
 ### Registry Location
 
+<<<<<<< HEAD
 - **Registry File:** `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`
+=======
+- **Registry File:** `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `$HOME/.config/ai-use-case-cli/agents.json`)
+>>>>>>> 40fde50 (docs: prefer XDG_CONFIG_HOME paths)
 - **Cache Directory:** `~/.cache/ai-use-case-cli/agents/`
 
 ### Configuration Options
 
+<<<<<<< HEAD
 Edit `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`:
+=======
+Edit `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json`:
+>>>>>>> 40fde50 (docs: prefer XDG_CONFIG_HOME paths)
 
 ```json
 {

--- a/docs/agents/opencode/README.md
+++ b/docs/agents/opencode/README.md
@@ -6,7 +6,7 @@ This document maps those concepts to OpenCode and lists the practical checks to 
 ## What OpenCode Needs
 
 - `AGENTS.md` at repo root: primary instructions OpenCode agents should follow.
-- Config is stored at `$XDG_CONFIG_HOME/ai-use-case-cli/config.json` (default: `~/.config/ai-use-case-cli/config.json`).
+- Config is stored at `$XDG_CONFIG_HOME/ai-use-case-cli/config.json` (default: `$HOME/.config/ai-use-case-cli/config.json`).
 - Project setup creates:
   - `.usecase/cases/`
   - `.ai-tools/commands/use-case/` (source-of-truth slash commands)

--- a/docs/diagrams/REVIEW-2025-12-06.md
+++ b/docs/diagrams/REVIEW-2025-12-06.md
@@ -15,7 +15,7 @@ The diagrams in `docs/diagrams/` need **moderate updates** to reflect recent arc
 **What Changed:**
 - New directory: `scripts/agents/`
 - New scripts: `agent-registry.sh`, `invoke-agent.sh`, `quality-agent.sh`
-- New configuration: `~/.config/ai-use-case-cli/agents.json`
+- New configuration: `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - New CLI commands: `ai-use-case agents`, `ai-use-case review-quality`
 - New slash command: `/use-case:review-quality`
 - 4 registered agents: quality-reviewer, pattern-analyzer, session-selector, organization-optimizer
@@ -39,7 +39,7 @@ Rel(core_scripts, agent_framework, "Invokes quality review", "Shell execution")
 
 For **Deployment Diagram** (c4-architecture.puml lines 144-207):
 ```plantuml
-Deployment_Node(user_config, "User Configuration", "~/.config/ai-use-case-cli") {
+Deployment_Node(user_config, "User Configuration", "$XDG_CONFIG_HOME/ai-use-case-cli") {
     ContainerDb(config_files, "Configuration Files", "JSON", "config.json, tracing.json, agents.json")
 }
 ```

--- a/docs/features/intelligent-agents-integration/01-feature-plan.md
+++ b/docs/features/intelligent-agents-integration/01-feature-plan.md
@@ -98,7 +98,7 @@ Users invoke agents explicitly via:
   - Parameter validation and context preparation
   - Result handling and error recovery
 
-- **Agent Configuration** (`~/.config/ai-use-case-cli/agents.json`)
+- **Agent Configuration** (`$XDG_CONFIG_HOME/ai-use-case-cli/agents.json`, default: `$HOME/.config/ai-use-case-cli/agents.json`)
   - User preferences for agent behavior
   - Enable/disable specific agents
   - Customization parameters per agent
@@ -342,7 +342,7 @@ ai-use-case optimize-organization
    - Add `analyze-patterns.md` - Pattern analysis command
    - Add `optimize-organization.md` - Organization command
 
-5. **New: `~/.config/ai-use-case-cli/agents.json`** - Agent configuration
+5. **New: `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json`** - Agent configuration (default: `$HOME/.config/ai-use-case-cli/agents.json`)
    - Enable/disable agents
    - Customize agent behavior
    - Track agent usage statistics
@@ -415,7 +415,7 @@ User Reviews & Applies
 - Create `scripts/agents/` directory structure
 - Implement `agent-registry.sh` with JSON-based registry
 - Implement `invoke-agent.sh` wrapper for Claude Code Task tool
-- Create `~/.config/ai-use-case-cli/agents.json` schema
+- Create `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` schema (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - Add `ai-use-case agents` subcommand to CLI
 - Write unit tests for agent framework
 - Document agent architecture in `docs/AGENTS.md`

--- a/docs/features/intelligent-agents-integration/02-requirements.md
+++ b/docs/features/intelligent-agents-integration/02-requirements.md
@@ -30,7 +30,7 @@
 
 - **Requirement:** System MUST provide a JSON-based agent registry that tracks all available agents
 - **Rationale:** Centralized management of agents, their capabilities, and status
-- **Validation:** Registry file exists at `~/.config/ai-use-case-cli/agents.json` with valid schema
+- **Validation:** Registry file exists at `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` with valid schema (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - **Schema:**
   ```json
   {
@@ -487,7 +487,7 @@
 
 ### AC-1: Agent Framework
 
-- [ ] Agent registry exists at `~/.config/ai-use-case-cli/agents.json`
+- [ ] Agent registry exists at `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - [ ] CLI command `ai-use-case agents list` works and shows all agents
 - [ ] Can enable/disable agents: `ai-use-case agents enable/disable <id>`
 - [ ] Agent statistics tracked correctly (invocations, success rate)
@@ -544,7 +544,7 @@
 
 ### DR-1: Agent Registry Schema
 
-**File:** `~/.config/ai-use-case-cli/agents.json`
+**File:** `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 
 **Schema:**
 ```json
@@ -736,7 +736,7 @@ ai-use-case agents config reset
 - **Bash Version:** Requires bash 4.0+ for associative arrays
 - **jq Dependency:** Required for JSON manipulation in agent registry
 - **Claude Code:** Agents require Claude Code, but CLI must work without it
-- **File System:** Agent registry and cache stored in `~/.config/ai-use-case-cli/`
+- **File System:** Agent registry and cache stored in `$XDG_CONFIG_HOME/ai-use-case-cli/` (default: `$HOME/.config/ai-use-case-cli/`)
 
 ### C-2: Performance Constraints
 

--- a/docs/features/intelligent-agents-integration/03-implementation-checklist.md
+++ b/docs/features/intelligent-agents-integration/03-implementation-checklist.md
@@ -56,7 +56,7 @@
 ### Task 1.1: Create Agent Registry Schema
 
 **Files:**
-- `~/.config/ai-use-case-cli/agents.json` (runtime)
+- `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` (runtime, default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - `scripts/agents/agent-registry.sh` (management script)
 
 **Priority:** High

--- a/docs/features/layered-architecture-restructure/02-requirements.md
+++ b/docs/features/layered-architecture-restructure/02-requirements.md
@@ -372,16 +372,16 @@
 **Requirement:** No changes to existing data structures
 
 **Configuration Files:**
-- `~/.config/ai-use-case-cli/config.json` - Unchanged
-- `~/.config/ai-use-case-cli/tracing.json` - Unchanged
-- `~/.config/ai-use-case-cli/agents.json` - Unchanged
+- `$XDG_CONFIG_HOME/ai-use-case-cli/config.json` - Unchanged (default: `$HOME/.config/ai-use-case-cli/config.json`)
+- `$XDG_CONFIG_HOME/ai-use-case-cli/tracing.json` - Unchanged (default: `$HOME/.config/ai-use-case-cli/tracing.json`)
+- `$XDG_CONFIG_HOME/ai-use-case-cli/agents.json` - Unchanged (default: `$HOME/.config/ai-use-case-cli/agents.json`)
 - `~/.local/share/ai-use-case-cli/projects-registry.json` - Unchanged
 
 **Rationale:** Data format stability ensures backward compatibility
 
 ### DR-2: Storage Locations
 
-- **Configuration:** `~/.config/ai-use-case-cli/` (unchanged)
+- **Configuration:** `$XDG_CONFIG_HOME/ai-use-case-cli/` (unchanged; default: `$HOME/.config/ai-use-case-cli/`)
 - **Registry:** `~/.local/share/ai-use-case-cli/` (unchanged)
 - **Hub:** Configured path (unchanged)
 - **Format:** JSON (unchanged)


### PR DESCRIPTION
## What
Standardize documentation to prefer `$XDG_CONFIG_HOME/ai-use-case-cli/*` paths (with `$HOME/.config` defaults) instead of hardcoding `~/.config/ai-use-case-cli`.

## Where
- `docs/COMMANDS.md`
- `docs/TRACING.md`
- `docs/CONFLUENCE-INTEGRATION.md`
- `docs/agents/*` (selected)
- `docs/diagrams/REVIEW-2025-12-06.md`
- `docs/features/*` (selected)
- `CHANGELOG.md`

## Verification
- `./scripts/utils/validate-versions.sh --unreleased` (warnings=0)
- `./run-tests.sh version` (pass)