### PR TITLE
feat: add yearly report to stats output

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -53,9 +53,9 @@ ai-use-case search <term>       # Search documented use cases
                                # - Shows matching files with context
 
 ai-use-case stats               # View statistics
-                               # - Total use cases
-                               # - By project
-                               # - Recent activity
+                                # - Total use cases
+                                # - By project
+                                # - Yearly report (last year + current year)
 ```
 
 ### Project Registry (v3.1.0+)

--- a/scripts/search/stats-use-cases.sh
+++ b/scripts/search/stats-use-cases.sh
@@ -8,13 +8,13 @@ set -e
 GREEN=$'\033[0;32m'
 BLUE=$'\033[0;34m'
 YELLOW=$'\033[1;33m'
-RED=$'\033[0;31m'
 NC=$'\033[0m'
 
 # Get script directory and source hub utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HUB_UTILS="$SCRIPT_DIR/../utils/hub-utils.sh"
 if [ -f "$HUB_UTILS" ]; then
+    # shellcheck disable=SC1090 # Source uses SCRIPT_DIR-resolved path
     source "$HUB_UTILS"
 fi
 
@@ -59,8 +59,21 @@ echo ""
 echo -e "${YELLOW}Total time saved (from documented sessions):${NC}"
 time_saved=$(grep -h "Time Saved:" by-project/*/*.md 2>/dev/null | \
     grep -oP '\d+(\.\d+)?' | \
-    awk '{sum+=$1} END {print sum}' || echo "0")
+    awk '{sum+=$1} END {print sum+0}' || echo "0")
 echo "  ~${time_saved} hours"
+
+echo ""
+echo -e "${YELLOW}Yearly report (last year + current year):${NC}"
+current_year=$(date '+%Y')
+last_year=$((current_year - 1))
+
+for year in "$last_year" "$current_year"; do
+    year_count=$(find by-project -name "${year}-W??-??-??_*.md" -type f 2>/dev/null | wc -l)
+    year_time_saved=$(grep -h "Time Saved:" by-project/*/"${year}-W"*.md 2>/dev/null | \
+        grep -oP '\d+(\.\d+)?' | \
+        awk '{sum+=$1} END {print sum+0}' || echo "0")
+    echo "  ${year}: ${year_count} use case(s), ~${year_time_saved} hours saved"
+done
 
 echo ""
 echo -e "${GREEN}Hub location:${NC} $HUB_DIR"

--- a/tests/stats.bats
+++ b/tests/stats.bats
@@ -159,3 +159,21 @@ CLI="$(script_path ai-use-case)"
     # Should only count the .md file
     assert_output --partial "1"
 }
+
+@test "stats-use-cases: includes yearly report for last and current year" {
+    local current_year
+    local last_year
+    current_year="$(date '+%Y')"
+    last_year="$((current_year - 1))"
+
+    mkdir -p "$TEST_HUB_DIR/by-project/yearly"
+    echo "# Last year" > "$TEST_HUB_DIR/by-project/yearly/${last_year}-W01-01-01_Y-001_last.md"
+    echo "# Current year" > "$TEST_HUB_DIR/by-project/yearly/${current_year}-W01-01-01_Y-002_current.md"
+    echo "# Current year 2" > "$TEST_HUB_DIR/by-project/yearly/${current_year}-W02-01-02_Y-003_current2.md"
+
+    run bash "$STATS_SCRIPT"
+    assert_success
+    assert_output --partial "Yearly report"
+    assert_output --partial "${last_year}: 1"
+    assert_output --partial "${current_year}: 2"
+}


### PR DESCRIPTION
## What
Enhance `ai-use-case stats` to include a default yearly summary for the previous calendar year and the current calendar year.

## Where
- `scripts/search/stats-use-cases.sh`
- `tests/stats.bats`
- `docs/COMMANDS.md`

## Notes
- Includes a targeted `# shellcheck disable=SC1090` comment because `hub-utils.sh` is sourced via a SCRIPT_DIR-resolved runtime path.

## Verification
- `./run-tests.sh` (pass)
- `shellcheck -x scripts/search/stats-use-cases.sh`
- `./scripts/utils/validate-versions.sh --unreleased` (warnings=0)