### PR TITLE
docs: address PR 204 review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Documentation Path Consistency**: Standardized agent registry examples to use `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json` and quoted shell snippets so examples remain portable
+
 - **AI Tool Prompt Template Display**: Fixed template being displayed to user instead of used internally
   - **Root Cause**: AI tool prompt files (Codex, Claude Code, GitHub Copilot) instructed AI to use bash `cat` commands to read templates, causing the full template content to be displayed in the terminal
   - **Impact**: When running `/use-case:document-session` in Codex or other AI tools, users saw the entire documentation template printed to screen instead of it being used internally to generate documentation

--- a/docs/agents/framework/README.md
+++ b/docs/agents/framework/README.md
@@ -56,7 +56,7 @@ Phase 1 provides the foundation for all intelligent agents:
 # Initialize the agent registry
 ai-use-case agents init
 
-# Registry created at: ~/.config/ai-use-case-cli/agents.json
+# Registry created at: ${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json
 ```
 
 ### 2. List Available Agents
@@ -140,7 +140,7 @@ ai-use-case agents stats quality-reviewer
 
 ### Components
 
-#### 1. Agent Registry (`~/.config/ai-use-case-cli/agents.json`)
+#### 1. Agent Registry (`${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`)
 
 JSON-based registry tracking all available agents:
 
@@ -425,12 +425,12 @@ ai-use-case agents reset
 
 ### Registry Location
 
-- **Registry File:** `~/.config/ai-use-case-cli/agents.json`
+- **Registry File:** `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`
 - **Cache Directory:** `~/.cache/ai-use-case-cli/agents/`
 
 ### Configuration Options
 
-Edit `~/.config/ai-use-case-cli/agents.json`:
+Edit `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`:
 
 ```json
 {
@@ -456,10 +456,10 @@ Edit `~/.config/ai-use-case-cli/agents.json`:
 
 ```bash
 # View current configuration
-cat ~/.config/ai-use-case-cli/agents.json | jq '.config'
+cat "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json" | jq '.config'
 
 # Edit configuration
-vi ~/.config/ai-use-case-cli/agents.json
+vi "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json"
 ```
 
 ---
@@ -513,10 +513,10 @@ ai-use-case agents enable agent-id
 **Solution:**
 ```bash
 # Fix registry permissions
-chmod 600 ~/.config/ai-use-case-cli/agents.json
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json"
 
 # Recreate registry if needed
-rm ~/.config/ai-use-case-cli/agents.json
+rm "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json"
 ai-use-case agents init
 ```
 

--- a/docs/features/intelligent-agents-integration/QUICKSTART.md
+++ b/docs/features/intelligent-agents-integration/QUICKSTART.md
@@ -137,7 +137,7 @@ vim scripts/agents/agent-registry.sh
 ```
 
 **Success Criteria:**
-- ✅ Registry exists at `~/.config/ai-use-case-cli/agents.json`
+- ✅ Registry exists at `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json`
 - ✅ Can list, enable, disable agents via CLI
 - ✅ Framework adds < 10ms overhead
 
@@ -365,11 +365,11 @@ ai-use-case stats
 **Check Agent Registry:**
 ```bash
 # View registry
-cat ~/.config/ai-use-case-cli/agents.json | jq '.'
+cat "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json" | jq '.'
 
 # Verify agent enabled
 jq '.agents[] | select(.id=="quality-reviewer") | .enabled' \
-  ~/.config/ai-use-case-cli/agents.json
+  "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json"
 ```
 
 **Test Agent Invocation:**
@@ -380,7 +380,7 @@ bash -x ./scripts/agents/invoke-agent.sh quality-reviewer \
 
 # Check statistics
 jq '.agents[] | select(.id=="quality-reviewer") | .statistics' \
-  ~/.config/ai-use-case-cli/agents.json
+  "${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json"
 ```
 
 **Verify Claude Code Connection:**


### PR DESCRIPTION
This pull request standardizes the documentation for the agent registry path across all relevant documentation files, ensuring consistency and compatibility with different user environments. All shell commands and references to the agent registry now use the `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json` pattern, making the examples more portable and robust. Additionally, shell code snippets are now quoted for improved clarity and reliability.

**Documentation Consistency and Portability:**

* Standardized all references to the agent registry path from `~/.config/ai-use-case-cli/agents.json` to `${XDG_CONFIG_HOME:-$HOME/.config}/ai-use-case-cli/agents.json` in `docs/agents/framework/README.md` and `docs/features/intelligent-agents-integration/QUICKSTART.md`, ensuring compatibility with both default and custom XDG config locations. [[1]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L59-R59) [[2]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L143-R143) [[3]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L428-R433) [[4]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L459-R462) [[5]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L516-R519) [[6]](diffhunk://#diff-7e28989d8fe449db6590e319f34c8ce91341c2644407e09c8c92de25b56837b0L140-R140) [[7]](diffhunk://#diff-7e28989d8fe449db6590e319f34c8ce91341c2644407e09c8c92de25b56837b0L368-R372) [[8]](diffhunk://#diff-7e28989d8fe449db6590e319f34c8ce91341c2644407e09c8c92de25b56837b0L383-R383)
* Updated all shell command examples to use quoted paths and the standardized variable, improving portability and correctness in copy-paste scenarios. [[1]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L459-R462) [[2]](diffhunk://#diff-ee8f041c30a6dec2033372b8e623d5b409a5d952eff63582720295d55e5d0935L516-R519) [[3]](diffhunk://#diff-7e28989d8fe449db6590e319f34c8ce91341c2644407e09c8c92de25b56837b0L368-R372) [[4]](diffhunk://#diff-7e28989d8fe449db6590e319f34c8ce91341c2644407e09c8c92de25b56837b0L383-R383)

**Changelog Update:**

* Added a changelog entry describing the documentation path consistency improvements and the quoting of shell snippets for portability.